### PR TITLE
Removed old ncsa llm and ollama models switch to new hpcgpt qwen3 model

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ Use `example.env` and `example.env.atlassian` as references. Export directly or 
 ### Core variables
 
 - `NCSA_LLM_URL` – Base URL for NCSA Hosted models provider
-- `NCSA_OLLAMA_URL` – Base URL for NCSA Ollama provider
 - `ILLINOIS_CHAT_API_KEY` – Required for `illinois-chat-server`
 
 ### Atlassian (containerized MCP)
@@ -143,7 +142,7 @@ Configure `.env.atlassian` (see `example.env.atlassian`). Common options:
 
 ## Usage Examples
 
-Inside the Opencode TUI, pick a model (e.g., `ncsaollama/qwen3:32b`) and ask the assistant to use tools.
+Inside the Opencode TUI, pick a model (e.g., `ncsahosted/Qwen/Qwen3-VL-32B-Instruct`) and ask the assistant to use tools.
 
 ### Slurm status
 
@@ -168,8 +167,21 @@ See `opencode.jsonc` for providers, models, and MCP server commands. Example pro
 ```json
 {
   "provider": {
-    "ncsahosted": { "options": { "baseURL": "{env:NCSA_LLM_URL}" } },
-    "ncsaollama": { "options": { "baseURL": "{env:NCSA_OLLAMA_URL}" } }
+    "ncsahosted": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "my_provider_name",
+      "options": {
+        "baseURL": "{env:my_url}" // load the url from a environment variable
+      },
+      "models": {
+        "Qwen/Qwen3-VL-32B-Instruct": {
+          "name": "my_model_name",
+          "options": {
+            "stream":true
+          }
+        }
+      }
+    }
   }
 }
 ```

--- a/example.env
+++ b/example.env
@@ -1,4 +1,3 @@
 # Need to provide these field youself.
 NCSA_LLM_URL=
-NCSA_OLLAMA_URL=
 ILLINOIS_CHAT_API_KEY=

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -2,7 +2,7 @@
   "$schema": "https://opencode.ai/config.json",
   "mode": {
     "support": {
-        "model": "ncsaollama/qwen3:32b",
+        "model": "ncsahosted/Qwen/Qwen3-VL-32B-Instruct",
         "prompt": "{file:./prompts/support.txt}",
         "tools": {
           "write": true,
@@ -19,85 +19,12 @@
         "baseURL": "{env:NCSA_LLM_URL}"
       },
       "models": {
-        "Qwen/Qwen2.5-VL-72B-Instruct": {
-          "name": "Qwen 72B",
+        "Qwen/Qwen3-VL-32B-Instruct": {
+          "name": "Qwen 3 32B Instruct",
           "options": {
             "stream":true
           }
         }
-      }
-    },
-    "ncsaollama": {
-      "npm": "@ai-sdk/openai-compatible",
-      "name": "NCSA Ollama",
-      "options": {
-        "baseURL": "{env:NCSA_OLLAMA_URL}"
-      },
-      "models": {
-        // Tested and works with mcp tools
-        "gpt-oss:20b": {
-          "name": "GPT-OSS 20B",
-          "options": {
-            "stream":true
-          }
-        },
-        "gpt-oss:120b": {
-          "name": "GPT-OSS 120B",
-          "options": {
-            "stream":true
-          }
-        },
-        "qwen3:32b": {
-          "name": "Qwen 3 32B",
-          "options": {
-            "stream":true
-          }
-        },
-        // Incredibly slow
-        "llama3.1:70b-instruct-fp16": {
-          "name": "Llama 3.1 70B Instruct FP16",
-          "options": {
-            "stream":true
-          }
-        },
-        // Doesn't seem to know about mcp tools but no api error
-        "llama4:16x17b": {
-          "name": "Llama 4 16x17B",
-          "options": {
-            "stream":true
-          }
-        }
-        // ### Doesn't support tools ###
-        // "deepseek-r1:14b-qwen-distill-fp16": {
-        //   "name": "DeepSeek R1 14B",
-        //   "options": {
-        //     "stream":true
-        //   }
-        // },
-        // "deepseek-r1:32b": {
-        //   "name": "DeepSeek R1 32B",
-        //   "options": {
-        //     "stream":true
-        //   }
-        // },
-        // "deepseek-r1:70b": {
-        //   "name": "DeepSeek R1 70B",
-        //   "options": {
-        //     "stream":true
-        //   }
-        // },
-        // "gemma3:27b": {
-        //   "name": "Gemma 3 27B",
-        //   "options": {
-        //     "stream":true
-        //   }
-        // },
-        // "llama-guard3:8b": {
-        //   "name": "Llama Guard 3 8B",
-        //   "options": {
-        //     "stream":true
-        //   }
-        // },  
       }
     }
   },
@@ -131,7 +58,7 @@
       // Description shown in the TUI
       "description": "Report an issue to the Delta support team",
       "agent": "support",
-      "model": "ncsaollama/qwen3:32b"
+      "model": "ncsahosted/Qwen/Qwen3-VL-32B-Instruct"
     }
   },
   // I'm disabling sharing as i don't think this is a feature we want on Delta


### PR DESCRIPTION
Switched to using the new qwen3 instruct model instead of previous endpoints. Users will need to change there NCSA_LLM_URL to the new endpoint for it to work. 