### PR TITLE
Some simplifications

### DIFF
--- a/charts/osc-mcp/Chart.yaml
+++ b/charts/osc-mcp/Chart.yaml
@@ -24,7 +24,3 @@ version: 0.1.8
 appVersion: "0.1.8"
 maintainers:
   - name: khsa1
-dependencies:
-  - name: osc-common
-    version: 0.14.2
-    repository: https://osc.github.io/osc-helm-charts

--- a/charts/osc-mcp/templates/deployment.yaml
+++ b/charts/osc-mcp/templates/deployment.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.enabled -}}
 {{- if .Values.osc_chat.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -70,5 +69,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- end }}
 {{- end }}

--- a/charts/osc-mcp/templates/deployment.yaml
+++ b/charts/osc-mcp/templates/deployment.yaml
@@ -17,8 +17,10 @@ spec:
         {{- include "osc-mcp.osc_chat.selectorLabels" . | nindent 8 }}
         receiver: '{{ index .Values.global.alert.receiver }}'
     spec:
+      {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
-        - name: {{ include "osc.common.imagePullSecret.name" . }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "osc-mcp.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
@@ -28,7 +30,7 @@ spec:
       {{- end }}
       containers:
         - name: osc-chat
-          image: {{ include "osc-mcp.image" (dict "imageRoot" .Values.osc_chat.image "global" .Values.global "env" (include "osc.common.environment" .)) }}
+          image: {{ include "osc-mcp.image" (dict "imageRoot" .Values.osc_chat.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.osc_chat.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/osc-mcp/templates/ingress.yaml
+++ b/charts/osc-mcp/templates/ingress.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.enabled -}}
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "osc-mcp.fullname" . -}}
 {{- $chatPort := .Values.osc_chat.port -}}
@@ -42,5 +41,4 @@ spec:
                 name: {{ $fullName }}-chat
                 port:
                   number: {{ $chatPort }}
-{{- end }}
 {{- end }}

--- a/charts/osc-mcp/templates/networkpolicy.yaml
+++ b/charts/osc-mcp/templates/networkpolicy.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.networkPolicy.create }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ include "osc-mcp.name" . }}
+  labels:
+    {{- include "osc-mcp.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "osc-mcp.selectorLabels" . | nindent 6 }}
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          {{- include "osc-mcp.selectorLabels" . | nindent 10 }}
+    {{- if .Values.networkPolicy.ingressNamespace }}
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: {{ .Values.networkPolicy.ingressNamespace }}
+    {{- end }}
+    {{- if .Values.networkPolicy.prometheusNamespace }}
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: {{ .Values.networkPolicy.prometheusNamespace }}
+    {{- end }}
+{{- end }}

--- a/charts/osc-mcp/templates/service.yaml
+++ b/charts/osc-mcp/templates/service.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,4 +15,3 @@ spec:
       name: http
   selector:
     {{- include "osc-mcp.osc_chat.selectorLabels" . | nindent 4 }}
-{{- end }}

--- a/charts/osc-mcp/templates/serviceaccount.yaml
+++ b/charts/osc-mcp/templates/serviceaccount.yaml
@@ -4,5 +4,7 @@ metadata:
   name: {{ include "osc-mcp.name" . }}
   labels:
     {{- include "osc-mcp.labels" . | nindent 4 }}
+{{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
-  - name: {{ include "osc.common.imagePullSecret.name" . }}
+  {{- tpl (toYaml .) $ | nindent 2 }}
+{{- end }}

--- a/charts/osc-mcp/templates/serviceaccount.yaml
+++ b/charts/osc-mcp/templates/serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,4 +6,3 @@ metadata:
     {{- include "osc-mcp.labels" . | nindent 4 }}
 imagePullSecrets:
   - name: {{ include "osc.common.imagePullSecret.name" . }}
-{{- end }}

--- a/charts/osc-mcp/values.yaml
+++ b/charts/osc-mcp/values.yaml
@@ -1,33 +1,12 @@
 global:
+  # @ignored
   imageRegistry: docker-registry.osc.edu
-  imagePullSecret:
-    name: osc-registry
-    # -- OSC registry password
-    # @default -- **required**
-    password:
-  oscServiceAccount: oscchat
-  database:
-    allowIngress: true
-  security:
-    allowInsecureImages: true
-  storageClass: local-ess
-  pvcLabels:
-    osc.edu/service-account: oscchat
-  pvcAnnotations:
-    osc.edu/fileset: PZS0645
-  fileset: PZS0645
-  # @ignored
-  webservicesDeploy:
-    create: false
-  # @ignored
-  debugGroups:
-    - sappstf
-  # @ignored
-  maintenanceGroups:
-    - sappstf
   # @ignored
   alert:
     receiver: sciapps
+  # @ignored
+  imagePullSecrets:
+    - name: osc-registry
 
 ingress:
   enabled: true
@@ -73,6 +52,13 @@ osc_chat:
       cpu: 250m
       memory: 256Mi
 
+networkPolicy:
+  # -- Create the Network Policy
+  create: true
+  # -- Ingress namespace to allow access
+  ingressNamespace: ingress-nginx
+  # -- Prometheus namespace to allow access
+  prometheusNamespace: prometheus
 
 #slurm:
 #  port: 8001

--- a/charts/osc-mcp/values.yaml
+++ b/charts/osc-mcp/values.yaml
@@ -29,10 +29,6 @@ global:
   alert:
     receiver: sciapps
 
-  ingress:
-    host: ""
-    hostAlias: ""
-
 ingress:
   enabled: true
   className: "nginx"
@@ -44,17 +40,15 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-buffer-size: 16k
     nginx.ingress.kubernetes.io/server-alias: '{{ .Values.ingress.hostAlias }}'
     nginx.ingress.kubernetes.io/whitelist-source-range: '131.187.45.7,192.148.247.0/24,10.0.0.0/8'
-  host: '{{ required "Ingress host must be defined in the global settings" .Values.global.ingress.host }}'
-  hostAlias: '{{ required "Ingress host should be defined in the global settings" .Values.global.ingress.hostAlias }}'
+  host:
+  hostAlias:
   tls:
     - hosts:
-      - '{{ .Values.ingress.host }}'
-      - '{{ .Values.ingress.hostAlias }}'
+      - '{{ required "Ingress host must be defined" .Values.ingress.host }}'
+      - '{{ required "Ingress host alias must be defined" .Values.ingress.hostAlias }}'
       secretName: osc-mcp
 
 replicaCount: 1
-
-enabled: true
 
 extraInitContainers: []
 


### PR DESCRIPTION
The "enabled" key doesn't make sense in this chart since you won't deploy this chart by itself and set "enabled=false" and that key doesn't need to exist for a parent chart to not include.  If "osc-chat" does not enable the subchart, the entire dependency is skipped so the extra conditional not needed here.

Avoid references to global ingress as that's really an OSC-site pattern and is going to conflict with actual "osc-chat" frontend ingress values.