### PR TITLE
Add opt-in Slurm job tracker

### DIFF
--- a/NCSA/README.md
+++ b/NCSA/README.md
@@ -23,6 +23,7 @@ See [`client-deployment/README.md`](client-deployment/README.md) for site-admin 
 ```bash
 curl -fsSL https://opencode.ai/install | bash
 export OPENCODE_CONFIG=/absolute/path/to/this/repo/NCSA/client-deployment/opencode.jsonc
+export OPENCODE_TUI_CONFIG=/absolute/path/to/this/repo/NCSA/client-deployment/tui.jsonc
 export NCSA_LLM_URL=https://your-endpoint/v1
 opencode
 ```
@@ -32,7 +33,7 @@ Set `NCSA_LLM_URL` and any MCP server credentials before starting (see Environme
 ## Features
 
 - **Support agent** — Delta specific assistant with a custom system prompt (`client-deployment/prompts/support.txt`).
-- **Slurm integration (MCP)** — `accounts`, `sinfo`, `squeue`, and `scontrol` via `slurm-mcp-server`.
+- **Slurm integration** — an opt-in, no-LLM sidebar tracker for immediate job status plus structured `list_jobs`, `get_job`, and `get_job_usage` MCP tools.
 - **Docs Q&A (MCP)** — Illinois Chat tools `query_delta_documentation` and `query_delta_ai_documentation`.
 - **Support reporting (MCP)** — `send_support_report` via `report-server`; users can also run the `/report` command.
 - **Ticket knowledge base (MCP)** — `search_tickets`, `get_ticket`, `list_clusters`, `get_cluster`, and `stats` via `knowledge-base-server` (`mcp_servers/ticket_server/`); indexes Q&A pairs produced by the `ticket-ingest/` pipeline.
@@ -73,6 +74,7 @@ graph TD
 - The **support** agent is the primary user-facing mode, configured with Delta-specific prompts and tool permissions.
 - In production on Delta, MCP servers run as remote HTTP endpoints on `dt-hpcgpt` (ports 8001–8004 for Slurm, Illinois Chat, report, and knowledge-base). For local development, run the Python servers from `mcp_servers/` and point the config URLs at `http://127.0.0.1:<port>/mcp`.
 - `slurm-mcp-server` shells out to local Slurm commands on the host where it runs.
+- The read-only tracker merges active `squeue --json` records with recent `sacct --json` history. The sidebar is off by default and polls only after the user runs `/jobs`.
 - `illinois-chat-server` calls the Illinois Chat API to answer questions from Delta and Delta AI documentation.
 - `report-server` creates Jira support tickets with session context.
 - `knowledge-base-server` (`mcp_servers/ticket_server/`) indexes clustered support-ticket Q&A pairs and serves bm25 search over them. Data comes from the `ticket-ingest/` pipeline.
@@ -85,6 +87,9 @@ NCSA/
     installer.sh
     module.lua
     opencode.jsonc
+    tui.jsonc
+    plugins/
+      slurm-sidebar/
     prompts/
       support.txt
       report.txt
@@ -106,7 +111,7 @@ Each MCP server has its own README with setup and configuration details.
 
 | Server | Tools | Purpose |
 |--------|-------|---------|
-| `slurm-mcp-server` | `accounts`, `sinfo`, `squeue`, `scontrol` | Query accounts, partitions, jobs, and job details |
+| `slurm-mcp-server` | `accounts`, `sinfo`, `squeue`, `scontrol`, `list_jobs`, `get_job`, `get_job_usage` | Query accounts, partitions, and structured active/recent job state |
 | `illinois-chat-server` | `query_delta_documentation`, `query_delta_ai_documentation` | Answer questions from Delta and Delta AI docs |
 | `report-server` | `send_support_report` | Create Jira support issues with conversation history and host/user context |
 | `knowledge-base-server` | `search_tickets`, `get_ticket`, `list_clusters`, `get_cluster`, `stats` | bm25 search over processed support-ticket Q&A pairs |
@@ -165,6 +170,8 @@ After starting OpenCode, interact with the support agent and ask it to use tools
 
 The assistant will call `sinfo` and `squeue` via `slurm-mcp-server`.
 
+For immediate status without an LLM call, run `/jobs` to toggle the sidebar tracker. It refreshes active jobs every 15 seconds and completed jobs from the current OpenCode session once per minute. Run `/jobs-refresh` for an immediate refresh.
+
 ### Delta/Delta AI docs Q&A
 
 "How do I submit a Slurm job on Delta?"
@@ -193,6 +200,7 @@ The site config lives at `client-deployment/opencode.jsonc`. Key settings:
 | `provider.ncsahosted` | OpenAI-compatible provider using `{env:NCSA_LLM_URL}` |
 | `mcp` | Remote MCP server URLs; toggle individual servers with `enabled` |
 | `command.report` | Custom `/report` command bound to the support agent |
+| `tui.jsonc` `plugin` | Loads the local `slurm-sidebar` TUI plugin |
 | `share` | Set to `"disabled"` on Delta |
 | `permission` | Default tool permissions (`edit` and `bash` require approval) |
 

--- a/NCSA/client-deployment/README.md
+++ b/NCSA/client-deployment/README.md
@@ -9,6 +9,9 @@ client-deployment/
   installer.sh       # Site OpenCode installer
   module.lua         # Lmod/Environment Modules template
   opencode.jsonc     # Site config template (providers, MCP, prompts)
+  tui.jsonc          # TUI config, including the Slurm sidebar plugin
+  plugins/
+    slurm-sidebar/   # Opt-in live Slurm status for the OpenCode sidebar
   prompts/
     support.txt      # Support agent system prompt
     report.txt       # `/report` command template
@@ -17,8 +20,10 @@ client-deployment/
 | File | Purpose |
 |------|---------|
 | `installer.sh` | Fork of the [official OpenCode installer](https://opencode.ai/install) with `--install-dir` and `--no-modify-path` |
-| `module.lua` | Lmod template that sets `PATH`, `OPENCODE_CONFIG`, and `NCSA_LLM_URL` |
+| `module.lua` | Lmod template that sets `PATH`, `OPENCODE_CONFIG`, `OPENCODE_TUI_CONFIG`, and `NCSA_LLM_URL` |
 | `opencode.jsonc` | Site config: provider, models, MCP server URLs, permissions, and prompt references |
+| `tui.jsonc` | TUI config that loads site-managed interface plugins |
+| `plugins/slurm-sidebar/` | Deterministic opt-in Slurm status plugin; it does not invoke an LLM |
 | `prompts/` | Prompt files referenced by `opencode.jsonc` via `{file:./prompts/...}` |
 
 ## Target site layout
@@ -29,6 +34,9 @@ Delta uses `/sw/external/` for system software. After deployment, the install ro
 /sw/external/opencode/
   bin/opencode
   opencode.json
+  tui.jsonc
+  plugins/
+    slurm-sidebar/
   prompts/
     support.txt
     report.txt
@@ -65,8 +73,11 @@ Copy the config and prompt files into the install root. Prompt paths in the conf
 
 ```bash
 mkdir -p /sw/external/opencode/prompts
+mkdir -p /sw/external/opencode/plugins
 
 cp opencode.jsonc /sw/external/opencode/opencode.json
+cp tui.jsonc /sw/external/opencode/tui.jsonc
+cp -R plugins/slurm-sidebar /sw/external/opencode/plugins/
 cp prompts/support.txt prompts/report.txt /sw/external/opencode/prompts/
 ```
 
@@ -92,6 +103,7 @@ Update the template for your site:
 | `root` | Software root (e.g. `/sw/external/opencode`) |
 | `version` | Module version string; should match the installed OpenCode release |
 | `OPENCODE_CONFIG` | Path to your site config (e.g. `/sw/external/opencode/delta-opencode.json`) |
+| `OPENCODE_TUI_CONFIG` | Path to the site TUI config (e.g. `/sw/external/opencode/tui.jsonc`) |
 | `NCSA_LLM_URL` | Base URL for your hosted OpenAI-compatible model endpoint |
 
 ## End user usage
@@ -103,7 +115,9 @@ module load hpc-gpt/1.15.13
 opencode
 ```
 
-Loading the module sets `OPENCODE_CONFIG` and `NCSA_LLM_URL` automatically. Users do not need a personal install or config export.
+Loading the module sets `OPENCODE_CONFIG`, `OPENCODE_TUI_CONFIG`, and `NCSA_LLM_URL` automatically. Users do not need a personal install or config export.
+
+The Slurm sidebar tracker is off by default and creates no scheduler requests until enabled with `/jobs`. While enabled, active jobs refresh every 15 seconds and completed jobs from the current session refresh once per minute. Run `/jobs` again to stop polling.
 
 ## Upgrading
 
@@ -131,6 +145,7 @@ For development, users can install the OpenCode client in their home directory b
 
 ```bash
 export OPENCODE_CONFIG=/path/to/opencode.jsonc
+export OPENCODE_TUI_CONFIG=/path/to/tui.jsonc
 export NCSA_LLM_URL=https://your-endpoint/v1
 opencode
 ```

--- a/NCSA/client-deployment/module.lua
+++ b/NCSA/client-deployment/module.lua
@@ -20,6 +20,7 @@ whatis("URL: https://opencode.ai")
 
 prepend_path("PATH", pathJoin(root, "bin"))
 setenv("OPENCODE_CONFIG", pathJoin(root, "delta-opencode.jsonc")) -- Set this to your own config file
+setenv("OPENCODE_TUI_CONFIG", pathJoin(root, "tui.jsonc"))
 setenv("NCSA_LLM_URL", "https://example.endpoint/v1") -- Set this to your own hosted model URL
 
 if (mode() == "load") then

--- a/NCSA/client-deployment/plugins/slurm-sidebar/index.tsx
+++ b/NCSA/client-deployment/plugins/slurm-sidebar/index.tsx
@@ -1,0 +1,269 @@
+import { For, Show, createSignal, onCleanup, onMount } from "solid-js"
+import type { TuiPluginModule } from "@opencode-ai/plugin/tui"
+
+import { querySacct, querySqueue, summarizeJobs } from "./slurm.js"
+
+const REFRESH_INTERVAL_MS = 15_000
+const COMPLETED_REFRESH_INTERVAL_MS = 60_000
+const MAX_VISIBLE_JOBS = 6
+
+function compactState(state: string) {
+  const names: Record<string, string> = {
+    CONFIGURING: "CF",
+    COMPLETING: "CG",
+    PENDING: "PD",
+    RUNNING: "R",
+    SUSPENDED: "S",
+  }
+  return names[state] ?? state.slice(0, 2)
+}
+
+function truncate(value: string, width: number) {
+  if (value.length <= width) return value
+  return `${value.slice(0, Math.max(0, width - 1))}~`
+}
+
+const plugin: TuiPluginModule = {
+  id: "ncsa-slurm-sidebar",
+  async tui(api) {
+    let activePanel: { toggle: () => void; refresh: () => void } | undefined
+    let enableOnMount = false
+    const sessionStarts = new Map<string, Date>()
+
+    const unregisterCommand = api.keymap.registerLayer({
+      commands: [
+        {
+          title: "Toggle Slurm job tracker",
+          name: "ncsa.slurm.jobs.toggle",
+          desc: "Enable or disable live Slurm jobs in the sidebar",
+          category: "HPC",
+          namespace: "palette",
+          slashName: "jobs",
+          run: () => {
+            if (activePanel) {
+              activePanel.toggle()
+              return
+            }
+            enableOnMount = true
+            api.keymap.dispatchCommand("session.sidebar.toggle")
+          },
+        },
+        {
+          title: "Refresh Slurm jobs",
+          name: "ncsa.slurm.jobs.refresh",
+          desc: "Refresh the enabled Slurm sidebar tracker now",
+          category: "HPC",
+          namespace: "palette",
+          slashName: "jobs-refresh",
+          run: () => {
+            if (activePanel) activePanel.refresh()
+            else api.ui.toast({ title: "Slurm jobs", message: "Enable the tracker with /jobs first." })
+          },
+        },
+      ],
+    })
+
+    api.lifecycle.onDispose(unregisterCommand)
+
+    api.slots.register({
+      slots: {
+        sidebar_content(context) {
+          const sessionStartedAt = sessionStarts.get(context.session_id) ?? new Date()
+          sessionStarts.set(context.session_id, sessionStartedAt)
+          const [enabled, setEnabled] = createSignal(enableOnMount)
+          const [jobs, setJobs] = createSignal<any[]>([])
+          const [completedJobs, setCompletedJobs] = createSignal<any[]>([])
+          const [activeExpanded, setActiveExpanded] = createSignal(true)
+          const [completedExpanded, setCompletedExpanded] = createSignal(false)
+          const [loading, setLoading] = createSignal(false)
+          const [error, setError] = createSignal<string>()
+          const [completedError, setCompletedError] = createSignal<string>()
+          const [updatedAt, setUpdatedAt] = createSignal<Date>()
+          let timer: ReturnType<typeof setTimeout> | undefined
+          let controller: AbortController | undefined
+          let requestID = 0
+          let inFlight = false
+          let lastCompletedRefresh = 0
+
+          const cancelTimer = () => {
+            if (timer) clearTimeout(timer)
+            timer = undefined
+          }
+
+          const stop = () => {
+            requestID += 1
+            cancelTimer()
+            controller?.abort()
+            controller = undefined
+            inFlight = false
+          }
+
+          const schedule = () => {
+            cancelTimer()
+            if (!enabled()) return
+            timer = setTimeout(() => void refresh(false), REFRESH_INTERVAL_MS)
+          }
+
+          const refresh = async (includeCompleted = true) => {
+            if (!enabled() || inFlight) return
+            inFlight = true
+            setLoading(true)
+            const currentRequest = ++requestID
+            const requestController = new AbortController()
+            controller = requestController
+            try {
+              const next = await querySqueue({ signal: requestController.signal })
+              if (currentRequest !== requestID || requestController.signal.aborted) return
+              setJobs(next)
+              setError(undefined)
+              if (includeCompleted || Date.now() - lastCompletedRefresh >= COMPLETED_REFRESH_INTERVAL_MS) {
+                try {
+                  const completed = await querySacct({ since: sessionStartedAt, signal: requestController.signal })
+                  if (currentRequest !== requestID || requestController.signal.aborted) return
+                  setCompletedJobs(completed)
+                  setCompletedError(undefined)
+                  lastCompletedRefresh = Date.now()
+                } catch (cause) {
+                  if (currentRequest === requestID && !requestController.signal.aborted) {
+                    setCompletedError(cause instanceof Error ? cause.message : String(cause))
+                  }
+                }
+              }
+              setUpdatedAt(new Date())
+            } catch (cause) {
+              if (currentRequest === requestID && !requestController.signal.aborted) {
+                setError(cause instanceof Error ? cause.message : String(cause))
+              }
+            } finally {
+              if (currentRequest === requestID) {
+                inFlight = false
+                setLoading(false)
+                controller = undefined
+                schedule()
+              }
+            }
+          }
+
+          const toggle = () => {
+            const next = !enabled()
+            setEnabled(next)
+            enableOnMount = next
+            if (next) {
+              lastCompletedRefresh = 0
+              void refresh(true)
+            } else {
+              stop()
+              setJobs([])
+              setCompletedJobs([])
+              setError(undefined)
+              setCompletedError(undefined)
+              setUpdatedAt(undefined)
+            }
+          }
+
+          activePanel = { toggle, refresh: () => void refresh(true) }
+
+          onMount(() => {
+            if (enabled()) void refresh(true)
+          })
+          onCleanup(() => {
+            stop()
+            if (activePanel?.toggle === toggle) activePanel = undefined
+          })
+
+          const summary = () => summarizeJobs(jobs())
+          const stateColor = (state: string) => {
+            if (state === "RUNNING") return context.theme.current.success
+            if (state === "PENDING") return context.theme.current.warning
+            return context.theme.current.info
+          }
+
+          return (
+            <box flexDirection="column" gap={1} paddingTop={1}>
+              <text fg={context.theme.current.text}>
+                <b>SLURM JOBS</b>{" "}
+                <span style={{ fg: enabled() ? context.theme.current.success : context.theme.current.textMuted }}>
+                  {enabled() ? "on" : "off"}
+                </span>
+              </text>
+
+              <Show when={!enabled()}>
+                <text fg={context.theme.current.textMuted}>/jobs to enable</text>
+              </Show>
+
+              <Show when={enabled()}>
+                <box flexDirection="column">
+                  <Show when={loading() && !updatedAt()}>
+                    <text fg={context.theme.current.textMuted}>Loading jobs...</text>
+                  </Show>
+                  <Show when={error()}>
+                    {(message) => <text fg={context.theme.current.error}>{truncate(message(), 34)}</text>}
+                  </Show>
+                  <text fg={context.theme.current.text} onMouseUp={() => setActiveExpanded((value) => !value)}>
+                    {activeExpanded() ? "[-]" : "[+]"} Active ({jobs().length})
+                  </text>
+                  <Show when={activeExpanded()}>
+                    <Show when={!loading() && !error() && jobs().length === 0}>
+                      <text fg={context.theme.current.textMuted}>  No active jobs</text>
+                    </Show>
+                    <For each={jobs().slice(0, MAX_VISIBLE_JOBS)}>
+                      {(job) => (
+                        <text fg={context.theme.current.textMuted}>
+                          <span style={{ fg: stateColor(job.state) }}>{compactState(job.state).padEnd(2)}</span>{" "}
+                          <span style={{ fg: context.theme.current.text }}>{truncate(job.id, 10).padEnd(10)}</span>{" "}
+                          {truncate(job.name, 14)}
+                        </text>
+                      )}
+                    </For>
+                    <Show when={jobs().length > MAX_VISIBLE_JOBS}>
+                      <text fg={context.theme.current.textMuted}>+{jobs().length - MAX_VISIBLE_JOBS} more</text>
+                    </Show>
+                  </Show>
+                  <Show when={jobs().length > 0}>
+                    <text fg={context.theme.current.textMuted}>
+                      {summary().running} running | {summary().pending} pending
+                    </text>
+                  </Show>
+                  <text fg={context.theme.current.text} onMouseUp={() => setCompletedExpanded((value) => !value)}>
+                    {completedExpanded() ? "[-]" : "[+]"} Completed ({completedJobs().length})
+                  </text>
+                  <Show when={completedExpanded()}>
+                    <Show when={completedError()}>
+                      {(message) => <text fg={context.theme.current.error}>  {truncate(message(), 32)}</text>}
+                    </Show>
+                    <Show when={!completedError() && completedJobs().length === 0}>
+                      <text fg={context.theme.current.textMuted}>  None this session</text>
+                    </Show>
+                    <For each={completedJobs().slice(0, MAX_VISIBLE_JOBS)}>
+                      {(job) => (
+                        <text fg={context.theme.current.textMuted}>
+                          <span style={{ fg: job.state === "COMPLETED" ? context.theme.current.success : context.theme.current.error }}>
+                            {compactState(job.state).padEnd(2)}
+                          </span>{" "}
+                          <span style={{ fg: context.theme.current.text }}>{truncate(job.id, 10).padEnd(10)}</span>{" "}
+                          {truncate(job.name, 14)}
+                        </text>
+                      )}
+                    </For>
+                    <Show when={completedJobs().length > MAX_VISIBLE_JOBS}>
+                      <text fg={context.theme.current.textMuted}>+{completedJobs().length - MAX_VISIBLE_JOBS} more</text>
+                    </Show>
+                  </Show>
+                  <Show when={updatedAt()}>
+                    {(updated) => (
+                      <text fg={context.theme.current.textMuted}>
+                        {loading() ? "Refreshing" : `Updated ${updated().toLocaleTimeString()}`} | 15s
+                      </text>
+                    )}
+                  </Show>
+                </box>
+              </Show>
+            </box>
+          )
+        },
+      },
+    })
+  },
+}
+
+export default plugin

--- a/NCSA/client-deployment/plugins/slurm-sidebar/package.json
+++ b/NCSA/client-deployment/plugins/slurm-sidebar/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ncsa-slurm-sidebar",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./tui": "./index.tsx"
+  },
+  "engines": {
+    "opencode": ">=1.17.0"
+  }
+}

--- a/NCSA/client-deployment/plugins/slurm-sidebar/slurm.js
+++ b/NCSA/client-deployment/plugins/slurm-sidebar/slurm.js
@@ -1,0 +1,168 @@
+const ACTIVE_STATES = new Set([
+  "CONFIGURING",
+  "COMPLETING",
+  "PENDING",
+  "RUNNING",
+  "RESIZING",
+  "REQUEUED",
+  "REQUEUE_FED",
+  "REQUEUE_HOLD",
+  "SIGNALING",
+  "STAGE_OUT",
+  "SUSPENDED",
+])
+const TERMINAL_STATES = new Set([
+  "BOOT_FAIL",
+  "CANCELLED",
+  "COMPLETED",
+  "DEADLINE",
+  "FAILED",
+  "NODE_FAIL",
+  "OUT_OF_MEMORY",
+  "PREEMPTED",
+  "TIMEOUT",
+])
+
+function numberValue(value) {
+  if (value && typeof value === "object" && "number" in value) {
+    if (value.set === false || value.infinite === true) return undefined
+    return value.number
+  }
+  return typeof value === "number" ? value : undefined
+}
+
+function stateValue(value) {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    value = value.current ?? value.state
+  }
+  if (Array.isArray(value)) return String(value[0] ?? "UNKNOWN")
+  return String(value ?? "UNKNOWN")
+}
+
+function reasonValue(job) {
+  const state = job.state
+  const reason =
+    (state && typeof state === "object" && !Array.isArray(state) ? state.reason : undefined) ??
+    job.state_reason ??
+    job.reason
+  if (!reason || reason === "None") return undefined
+  return String(reason)
+}
+
+function jobID(job) {
+  const raw = job.job_id ?? job.job_id_str ?? job.id
+  let id = raw === undefined || raw === null ? "" : String(raw)
+  const array = job.array && typeof job.array === "object" ? job.array : {}
+  const task = numberValue(array.task_id ?? job.array_task_id)
+  if (task !== undefined && !id.includes("_")) id = `${id}_${task}`
+  return id
+}
+
+function elapsedSeconds(job) {
+  const time = job.time && typeof job.time === "object" ? job.time : {}
+  const elapsed = numberValue(time.elapsed ?? job.time_used)
+  if (elapsed !== undefined) return elapsed
+  const start = numberValue(time.start ?? job.start_time)
+  if (!start) return 0
+  return Math.max(0, Math.floor(Date.now() / 1000) - start)
+}
+
+export function formatDuration(seconds) {
+  const total = Math.max(0, Math.floor(seconds || 0))
+  const days = Math.floor(total / 86400)
+  const hours = Math.floor((total % 86400) / 3600)
+  const minutes = Math.floor((total % 3600) / 60)
+  const secs = total % 60
+  const clock = `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${String(secs).padStart(2, "0")}`
+  return days ? `${days}-${clock}` : clock
+}
+
+export function normalizeSqueue(payload) {
+  if (!payload || !Array.isArray(payload.jobs)) return []
+  return payload.jobs
+    .map((job) => {
+      const state = stateValue(job.state ?? job.job_state)
+      return {
+        id: jobID(job),
+        name: String(job.name ?? job.job_name ?? ""),
+        state,
+        reason: reasonValue(job),
+        partition: String(job.partition ?? ""),
+        elapsedSeconds: elapsedSeconds(job),
+      }
+    })
+    .filter((job) => job.id && ACTIVE_STATES.has(job.state))
+    .sort((left, right) => {
+      const stateOrder = (state) => (state === "RUNNING" ? 0 : state === "PENDING" ? 1 : 2)
+      return stateOrder(left.state) - stateOrder(right.state) || Number(right.id.split("_")[0]) - Number(left.id.split("_")[0])
+    })
+}
+
+export function normalizeSacct(payload) {
+  if (!payload || !Array.isArray(payload.jobs)) return []
+  return payload.jobs
+    .map((job) => {
+      const state = stateValue(job.state ?? job.job_state)
+      const time = job.time && typeof job.time === "object" ? job.time : {}
+      return {
+        id: jobID(job),
+        name: String(job.name ?? job.job_name ?? ""),
+        state,
+        endedAt: numberValue(time.end ?? job.end_time) ?? 0,
+      }
+    })
+    .filter((job) => job.id && TERMINAL_STATES.has(job.state))
+    .sort((left, right) => right.endedAt - left.endedAt || Number(right.id) - Number(left.id))
+}
+
+export function summarizeJobs(jobs) {
+  return jobs.reduce(
+    (summary, job) => {
+      if (job.state === "RUNNING") summary.running += 1
+      else if (job.state === "PENDING") summary.pending += 1
+      else summary.other += 1
+      return summary
+    },
+    { running: 0, pending: 0, other: 0 },
+  )
+}
+
+async function querySlurm(command, commandName, normalize, { timeoutMs = 5000, signal } = {}) {
+  const process = Bun.spawn({ cmd: command, stdout: "pipe", stderr: "pipe" })
+  let timedOut = false
+  const stop = () => process.kill()
+  signal?.addEventListener("abort", stop, { once: true })
+  const timer = setTimeout(() => {
+    timedOut = true
+    process.kill()
+  }, timeoutMs)
+
+  try {
+    const [exitCode, stdout, stderr] = await Promise.all([
+      process.exited,
+      new Response(process.stdout).text(),
+      new Response(process.stderr).text(),
+    ])
+    if (timedOut) throw new Error(`${commandName} timed out after ${timeoutMs / 1000} seconds`)
+    if (signal?.aborted) throw new Error(`${commandName} query cancelled`)
+    if (exitCode !== 0) throw new Error(stderr.trim() || `${commandName} exited with code ${exitCode}`)
+    const payload = JSON.parse(stdout)
+    if (Array.isArray(payload.errors) && payload.errors.length) {
+      throw new Error(payload.errors.map((item) => item.description ?? String(item)).join("; "))
+    }
+    return normalize(payload)
+  } finally {
+    clearTimeout(timer)
+    signal?.removeEventListener("abort", stop)
+  }
+}
+
+export function querySqueue(options = {}) {
+  return querySlurm(["squeue", "--me", "--json"], "squeue", normalizeSqueue, options)
+}
+
+export function querySacct({ since, ...options } = {}) {
+  if (!(since instanceof Date) || Number.isNaN(since.valueOf())) throw new Error("querySacct requires a valid start time")
+  const local = new Date(since.getTime() - since.getTimezoneOffset() * 60_000).toISOString().slice(0, 19)
+  return querySlurm(["sacct", "--allocations", "--json", "--starttime", local], "sacct", normalizeSacct, options)
+}

--- a/NCSA/client-deployment/plugins/slurm-sidebar/slurm.test.js
+++ b/NCSA/client-deployment/plugins/slurm-sidebar/slurm.test.js
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { formatDuration, normalizeSacct, normalizeSqueue, summarizeJobs } from "./slurm.js"
+
+const payload = {
+  jobs: [
+    {
+      job_id: 1234,
+      name: "training",
+      partition: "gpu",
+      job_state: ["RUNNING"],
+      time: { elapsed: 65 },
+    },
+    {
+      job_id: 1235,
+      array: { task_id: { set: true, infinite: false, number: 2 } },
+      name: "preprocess",
+      partition: "cpu",
+      state: { current: ["PENDING"], reason: "Priority" },
+      time: { elapsed: 0 },
+    },
+    {
+      job_id: 1200,
+      name: "finished",
+      job_state: ["COMPLETED"],
+    },
+  ],
+}
+
+test("normalizes and sorts active squeue jobs", () => {
+  const jobs = normalizeSqueue(payload)
+  assert.deepEqual(jobs.map((job) => job.id), ["1234", "1235_2"])
+  assert.equal(jobs[0].elapsedSeconds, 65)
+  assert.equal(jobs[1].reason, "Priority")
+})
+
+test("summarizes states and formats elapsed time", () => {
+  const jobs = normalizeSqueue(payload)
+  assert.deepEqual(summarizeJobs(jobs), { running: 1, pending: 1, other: 0 })
+  assert.equal(formatDuration(90061), "1-01:01:01")
+})
+
+test("normalizes completed allocations and excludes active jobs", () => {
+  const jobs = normalizeSacct({
+    jobs: [
+      { job_id: 2001, name: "done", state: { current: ["COMPLETED"] }, time: { end: 200 } },
+      { job_id: 2002, name: "failed", state: { current: ["FAILED"] }, time: { end: 300 } },
+      { job_id: 2003, name: "active", state: { current: ["RUNNING"] }, time: { end: 0 } },
+    ],
+  })
+  assert.deepEqual(jobs.map((job) => job.id), ["2002", "2001"])
+})

--- a/NCSA/client-deployment/prompts/support.txt
+++ b/NCSA/client-deployment/prompts/support.txt
@@ -26,6 +26,9 @@ You have access to several powerful tools:
 - **sinfo**: View node availability and partition information
 - **squeue**: Monitor running and queued jobs
 - **scontrol**: Get detailed job and system information
+- **list_jobs**: Show active jobs plus recent accounting history as structured data
+- **get_job**: Get structured status and log paths for one job
+- **get_job_usage**: Get accounting and step usage for one completed or running job
 
 ### System Tools
 - **bash**: Execute system commands when needed for troubleshooting

--- a/NCSA/client-deployment/tui.jsonc
+++ b/NCSA/client-deployment/tui.jsonc
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://opencode.ai/tui.json",
+  "plugin": ["./plugins/slurm-sidebar"]
+}

--- a/NCSA/mcp_servers/slurm_server/README.md
+++ b/NCSA/mcp_servers/slurm_server/README.md
@@ -1,8 +1,8 @@
 # Slurm MCP Server (Python)
 
-A [Model Context Protocol](https://modelcontextprotocol.io/) server built with [FastMCP](https://github.com/jlowin/fastmcp). It exposes thin wrappers around local **Slurm** and **`accounts`** commands so an assistant can inspect partitions, queues, and account usage on a cluster node where those binaries exist and your user has permission to run them.
+A [Model Context Protocol](https://modelcontextprotocol.io/) server built with [FastMCP](https://github.com/jlowin/fastmcp). It exposes thin wrappers around local **Slurm** and **`accounts`** commands plus a read-only structured job tracker.
 
-Clients connect with **Streamable HTTP** to a URL such as `http://127.0.0.1:8001/mcp`.
+Clients connect through **Streamable HTTP** or run the server as a local **stdio** sidecar.
 
 ## Tools
 
@@ -11,14 +11,18 @@ Clients connect with **Streamable HTTP** to a URL such as `http://127.0.0.1:8001
 | `accounts` | Runs `accounts -u <username>` and returns stdout (site-specific accounting utility; must exist on `PATH`). |
 | `sinfo` | Runs `sinfo` with optional extra arguments as a single string (e.g. `-N`, `-o "..."`). |
 | `squeue` | Runs `squeue` with optional extra arguments as a single string. |
-| `scontrol` | Runs `scontrol` with optional `scontrol_args` (the `job_id` parameter is currently unused in the implementation). |
+| `scontrol` | Runs `scontrol show job <job_id>` with optional extra arguments. |
+| `list_jobs` | Merges active `squeue --json` data with recent `sacct --json` history and returns normalized jobs. |
+| `get_job` | Returns normalized status, resources, exit code, and log paths for one job. |
+| `get_job_usage` | Returns available Slurm accounting data for a job and its steps. |
 
-Returned text is **standard output only**; stderr is not merged into the tool result. Failed commands may still return empty output—check cluster policies and the server log file.
+The tracker is read-only. It cannot submit, cancel, hold, release, or otherwise modify jobs. The four legacy wrappers return command text; the tracker tools return structured objects and surface command failures.
 
 ## Requirements
 
 - **Python** 3.10+ (tested in line with other MCP servers in this repo)
 - **Slurm client tools** (`sinfo`, `squeue`, `scontrol`) on `PATH` if you use those tools
+- **Slurm accounting tools** (`sacct`) if you use recent history or usage tracking
 - **`accounts`** on `PATH` if you use `accounts` (many sites use a custom or scheduler-specific binary)
 - Python packages (from the repo directory):
 
@@ -35,8 +39,10 @@ Create or edit `config.json` in the server directory (or pass `-c /path/to/confi
 | `host` | Bind address (default `127.0.0.1`). |
 | `port` | Listen port (default `8001`). |
 | `log_file` | Append-only log path; parent directory is created if needed. |
+| `transport` | `streamable-http` (default) or `stdio`. |
+| `identity_mode` | `explicit` requires a tool username; `process` always uses the MCP process's effective Unix account. |
 
-Command-line flags override the file: `--host`, `--port`, `--log-file`, `-v` / `--verbose`. See `python server.py --help`.
+Command-line flags override the file: `--host`, `--port`, `--log-file`, `--transport`, `--identity-mode`, `-v` / `--verbose`. See `python server.py --help`.
 
 Example `config.json`:
 
@@ -44,7 +50,9 @@ Example `config.json`:
 {
   "host": "127.0.0.1",
   "port": 8001,
-  "log_file": "logs/Latest.log"
+  "log_file": "logs/Latest.log",
+  "transport": "streamable-http",
+  "identity_mode": "explicit"
 }
 ```
 
@@ -55,13 +63,34 @@ From `NCSA/mcp_servers/slurm_server`:
 ```bash
 python server.py
 python server.py -c /path/to/config.json -v
+python server.py --transport stdio --identity-mode process
 ```
 
 - **MCP endpoint:** `http://<host>:<port>/mcp`
 
 Point your MCP client at that URL with **Streamable HTTP** transport.
 
-**Security:** This process executes arbitrary argument strings passed into `sinfo` / `squeue` / `scontrol` (and fixed `accounts -u`). Bind to localhost or place behind authentication and a trusted network; do not expose directly to the public internet.
+For a per-user OpenCode deployment, prefer `stdio` with `identity_mode=process`. The server then inherits the user's Unix identity and ignores any username supplied by the model. A shared HTTP deployment has no authenticated Unix caller identity, so it must use `explicit` mode and should be restricted to a trusted network.
+
+## Tracker examples
+
+The equivalent scheduler commands are:
+
+```bash
+squeue --json -u "$USER"
+sacct -X --json -u "$USER" -S now-24hours
+sacct --json -u "$USER" -j 123456
+```
+
+`list_jobs` defaults to 24 hours of completed history, accepts compact lookbacks such as `30m`, `24h`, `7d`, or `12w`, caps history at 90 days, and caps returned results at 200 jobs. Scheduler commands time out after 20 seconds. Historical visibility still depends on the cluster's Slurm accounting retention.
+
+Run the fixture-based tests without contacting Slurm:
+
+```bash
+python -m unittest discover -s tests -v
+```
+
+**Security:** The legacy `sinfo` / `squeue` / `scontrol` tools accept argument strings. Tracker tools use fixed argument vectors and validate usernames, job IDs, lookbacks, and limits. Bind HTTP deployments to localhost or place them behind authentication and a trusted network; do not expose them directly to the public internet.
 
 ## Project layout
 
@@ -72,7 +101,9 @@ slurm_server/
 ├── config.json         # Local config (optional; create from example above)
 ├── src/
 │   ├── config.py       # Pydantic config loading
+│   ├── tracker.py      # Structured read-only job tracker
 │   └── logging.py      # File logging and FastMCP log routing
+├── tests/              # Fixture-based tracker tests
 └── logs/               # Typical location for log_file (optional)
 ```
 

--- a/NCSA/mcp_servers/slurm_server/example.config.json
+++ b/NCSA/mcp_servers/slurm_server/example.config.json
@@ -1,5 +1,7 @@
 {
-    "host": "127.0.0.1",
-    "port": 8001,
-    "log_file": "logs/Latest.log"
+  "host": "127.0.0.1",
+  "port": 8001,
+  "log_file": "logs/Latest.log",
+  "transport": "streamable-http",
+  "identity_mode": "explicit"
 }

--- a/NCSA/mcp_servers/slurm_server/server.py
+++ b/NCSA/mcp_servers/slurm_server/server.py
@@ -7,6 +7,7 @@ from fastmcp import FastMCP
 
 from src.config import Config, consolidate_config_and_args
 from src.logging import route_fastmcp_logs_to_root, setup_logging
+from src.tracker import SlurmTracker
 
 class SlurmMCP(FastMCP):
     """
@@ -15,10 +16,15 @@ class SlurmMCP(FastMCP):
     def __init__(self, name: str, args: argparse.Namespace):
         super().__init__(name)
 
+        self.tracker = SlurmTracker(identity_mode=args.identity_mode)
+
         self.add_tool(self.accounts)
         self.add_tool(self.sinfo)
         self.add_tool(self.squeue)
         self.add_tool(self.scontrol)
+        self.add_tool(self.list_jobs)
+        self.add_tool(self.get_job)
+        self.add_tool(self.get_job_usage)
 
     def _run_command(self, base_command: str, arg_string: str = "") -> str:
         """
@@ -96,6 +102,25 @@ class SlurmMCP(FastMCP):
             command_args = f"show job {job_id}" + (f" {command_args}" if command_args else "")
         return self._run_command("scontrol", command_args)
 
+    async def list_jobs(
+        self,
+        username: str | None = None,
+        states: list[str] | None = None,
+        since: str = "24h",
+        limit: int = 50,
+        include_completed: bool = True,
+    ) -> dict:
+        """List a user's active and recent Slurm jobs as structured data."""
+        return self.tracker.list_jobs(username, states, since, limit, include_completed)
+
+    async def get_job(self, job_id: str, username: str | None = None) -> dict:
+        """Get structured status and paths for one user-owned Slurm job."""
+        return self.tracker.get_job(job_id, username)
+
+    async def get_job_usage(self, job_id: str, username: str | None = None) -> dict:
+        """Get accounting and step usage for one user-owned Slurm job."""
+        return self.tracker.get_job_usage(job_id, username)
+
 def parse_command_line() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Slurm MCP Server",
@@ -117,6 +142,14 @@ def parse_command_line() -> argparse.Namespace:
         type=str,
         help="Option to set the file logging will output to.",
     )
+    parser.add_argument("--transport",
+        choices=("streamable-http", "stdio"),
+        help="MCP transport to use.",
+    )
+    parser.add_argument("--identity-mode",
+        choices=("explicit", "process"),
+        help="Resolve users from tool arguments or the MCP process account.",
+    )
     parser.add_argument("-v","--verbose",
         action="store_true",
         help="Flag to change the log level of the console from INFO to DEBUG",
@@ -137,7 +170,10 @@ def main(args: argparse.Namespace) -> None:
     route_fastmcp_logs_to_root(file_log_level)
 
     server = SlurmMCP("Slurm MCP Server", args)
-    server.run(transport="streamable-http", host=args.host, port=args.port, log_level=None, uvicorn_config={"log_config": None})
+    if args.transport == "stdio":
+        server.run(transport="stdio", log_level=None)
+    else:
+        server.run(transport="streamable-http", host=args.host, port=args.port, log_level=None, uvicorn_config={"log_config": None})
 
 if __name__ == "__main__":
     # Load config and args

--- a/NCSA/mcp_servers/slurm_server/src/config.py
+++ b/NCSA/mcp_servers/slurm_server/src/config.py
@@ -1,4 +1,6 @@
 import argparse
+from pathlib import Path
+from typing import Literal
 from pydantic import BaseModel, Field
 
 class Config(BaseModel):
@@ -11,15 +13,23 @@ class Config(BaseModel):
     log_file: str = Field(
         default="logs/Latest.log", 
         description="The file to write server logs to")
+    transport: Literal["streamable-http", "stdio"] = Field(
+        default="streamable-http",
+        description="MCP transport: streamable-http or stdio")
+    identity_mode: Literal["explicit", "process"] = Field(
+        default="explicit",
+        description="Use an explicit tool username or the MCP process Unix user")
 
     @classmethod
     def load_from_json(cls, filepath: str = "config.json") -> "Config":
-        with open(filepath, "r") as f:
-            return cls.model_validate_json(f.read())
+        path = Path(filepath)
+        if not path.exists() and filepath == "config.json":
+            return cls()
+        return cls.model_validate_json(path.read_text())
 
 def consolidate_config_and_args(config: Config, args: argparse.Namespace):
     # Merge config and args into a single args, with args taking precedence
     for key, value in config.__dict__.items():
-        if key.replace("_", "-") not in args.__dict__ or args.__dict__[key] is None:
+        if key not in args.__dict__ or args.__dict__[key] is None:
             args.__dict__[key] = value
     return args

--- a/NCSA/mcp_servers/slurm_server/src/tracker.py
+++ b/NCSA/mcp_servers/slurm_server/src/tracker.py
@@ -1,0 +1,360 @@
+"""Read-only, structured Slurm job tracking."""
+
+from __future__ import annotations
+
+import json
+import os
+import pwd
+import re
+import subprocess
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+
+CommandRunner = Callable[[list[str]], str]
+
+_USERNAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.-]{0,63}$")
+_JOB_ID_RE = re.compile(r"^\d+(?:_\d+)?(?:\+\d+)?$")
+_LOOKBACK_RE = re.compile(r"^[1-9]\d{0,2}[mhdw]$")
+_LOOKBACK_SECONDS = {"m": 60, "h": 3600, "d": 86400, "w": 604800}
+_MAX_LOOKBACK_SECONDS = 90 * 86400
+_COMMAND_TIMEOUT_SECONDS = 20
+
+ACTIVE_STATES = {
+    "CONFIGURING",
+    "COMPLETING",
+    "PENDING",
+    "RUNNING",
+    "RESIZING",
+    "REQUEUED",
+    "REQUEUE_FED",
+    "REQUEUE_HOLD",
+    "SIGNALING",
+    "STAGE_OUT",
+    "SUSPENDED",
+}
+
+
+class SlurmCommandError(RuntimeError):
+    """Raised when Slurm cannot return valid structured data."""
+
+
+def process_username() -> str:
+    """Return the effective Unix account, without trusting environment variables."""
+    return pwd.getpwuid(os.geteuid()).pw_name
+
+
+def run_json_command(command: list[str]) -> str:
+    """Run a fixed argv command and return stdout."""
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_COMMAND_TIMEOUT_SECONDS,
+        )
+    except FileNotFoundError as exc:
+        raise SlurmCommandError(f"Slurm command not found: {command[0]}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise SlurmCommandError(
+            f"{command[0]} did not finish within {_COMMAND_TIMEOUT_SECONDS} seconds"
+        ) from exc
+    if result.returncode != 0:
+        details = (result.stderr or result.stdout or "No error output").strip()
+        raise SlurmCommandError(
+            f"{' '.join(command)} failed with exit code {result.returncode}: {details}"
+        )
+    return result.stdout
+
+
+def _number(value: Any) -> int | float | None:
+    if isinstance(value, dict) and "number" in value:
+        if value.get("set") is False or value.get("infinite") is True:
+            return None
+        value = value["number"]
+    return value if isinstance(value, (int, float)) and not isinstance(value, bool) else None
+
+
+def _timestamp(value: Any) -> str | None:
+    seconds = _number(value)
+    if not seconds:
+        return None
+    return datetime.fromtimestamp(seconds, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _duration(seconds: Any) -> str | None:
+    value = _number(seconds)
+    if value is None:
+        return None
+    value = int(value)
+    days, remainder = divmod(value, 86400)
+    hours, remainder = divmod(remainder, 3600)
+    minutes, secs = divmod(remainder, 60)
+    prefix = f"{days}-" if days else ""
+    return f"{prefix}{hours:02d}:{minutes:02d}:{secs:02d}"
+
+
+def _state(value: Any) -> str:
+    if isinstance(value, dict):
+        value = value.get("current", value.get("state", "UNKNOWN"))
+    if isinstance(value, list):
+        return str(value[0]) if value else "UNKNOWN"
+    return str(value or "UNKNOWN")
+
+
+def _state_reason(value: Any) -> str | None:
+    if isinstance(value, dict):
+        reason = value.get("reason")
+        if reason and reason != "None":
+            return str(reason)
+    return None
+
+
+def _user_name(value: Any) -> str | None:
+    if isinstance(value, dict):
+        return value.get("name") or value.get("user")
+    return str(value) if value else None
+
+
+def _tres(items: Any) -> dict[str, int | float]:
+    if not isinstance(items, list):
+        return {}
+    resources: dict[str, int | float] = {}
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        resource_type = item.get("type")
+        if not resource_type:
+            continue
+        name = item.get("name")
+        key = f"{resource_type}/{name}" if name else str(resource_type)
+        count = _number(item.get("count"))
+        if count is not None:
+            resources[key] = count
+    return resources
+
+
+def _exit_code(value: Any) -> str | None:
+    if not isinstance(value, dict):
+        return str(value) if value else None
+    return_code = _number(value.get("return_code"))
+    signal = value.get("signal", {})
+    signal_id = _number(signal.get("id")) if isinstance(signal, dict) else None
+    if return_code is None and signal_id is None:
+        return None
+    return f"{int(return_code or 0)}:{int(signal_id or 0)}"
+
+
+def _job_id(job: dict[str, Any]) -> str:
+    value = job.get("job_id") or job.get("job_id_str") or job.get("id")
+    result = str(value) if value is not None else ""
+    array = job.get("array") if isinstance(job.get("array"), dict) else {}
+    task_id = _number(array.get("task_id") or job.get("array_task_id"))
+    if task_id is not None and "_" not in result:
+        result = f"{result}_{int(task_id)}"
+    return result
+
+
+def normalize_job(job: dict[str, Any], source: str) -> dict[str, Any]:
+    """Normalize the overlapping squeue/sacct job fields used by the UI."""
+    time = job.get("time") if isinstance(job.get("time"), dict) else {}
+    required = job.get("required") if isinstance(job.get("required"), dict) else {}
+    tres = job.get("tres") if isinstance(job.get("tres"), dict) else {}
+    nodes = job.get("nodes")
+    if isinstance(nodes, dict):
+        nodes = nodes.get("range") or ",".join(nodes.get("list", []))
+
+    state_value = job.get("state") or job.get("job_state")
+    return {
+        "job_id": _job_id(job),
+        "name": job.get("name") or job.get("job_name") or "",
+        "user": _user_name(job.get("user")),
+        "account": job.get("account"),
+        "partition": job.get("partition"),
+        "qos": job.get("qos"),
+        "state": _state(state_value),
+        "state_reason": _state_reason(state_value) or job.get("state_reason"),
+        "nodes": nodes,
+        "node_count": _number(job.get("allocation_nodes"))
+        or _number(job.get("node_count")),
+        "cpus": _number(required.get("CPUs")) or _number(job.get("cpus")),
+        "resources": _tres(tres.get("allocated") or tres.get("requested")),
+        "submitted_at": _timestamp(time.get("submission") or job.get("submit_time")),
+        "started_at": _timestamp(time.get("start") or job.get("start_time")),
+        "ended_at": _timestamp(time.get("end") or job.get("end_time")),
+        "elapsed": _duration(time.get("elapsed")),
+        "time_limit_minutes": _number(time.get("limit") or job.get("time_limit")),
+        "exit_code": _exit_code(job.get("exit_code")),
+        "stdout": job.get("stdout_expanded") or job.get("stdout"),
+        "stderr": job.get("stderr_expanded") or job.get("stderr"),
+        "working_directory": job.get("working_directory"),
+        "source": source,
+    }
+
+
+def _parse_payload(text: str, command_name: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise SlurmCommandError(f"{command_name} returned invalid JSON") from exc
+    errors = payload.get("errors", [])
+    if errors:
+        descriptions = [str(item.get("description", item)) for item in errors]
+        raise SlurmCommandError(f"{command_name} reported: {'; '.join(descriptions)}")
+    return payload
+
+
+def _slurm_start_time(lookback: str) -> str:
+    units = {"m": "minutes", "h": "hours", "d": "days", "w": "weeks"}
+    return f"now-{lookback[:-1]}{units[lookback[-1]]}"
+
+
+class SlurmTracker:
+    """Query Slurm and expose a compact, user-scoped job view."""
+
+    def __init__(
+        self,
+        identity_mode: str = "explicit",
+        runner: CommandRunner = run_json_command,
+    ) -> None:
+        if identity_mode not in {"explicit", "process"}:
+            raise ValueError("identity_mode must be 'explicit' or 'process'")
+        self.identity_mode = identity_mode
+        self.runner = runner
+
+    def resolve_username(self, username: str | None) -> str:
+        resolved = process_username() if self.identity_mode == "process" else username
+        if not resolved:
+            raise ValueError("username is required for a remote Slurm tracker")
+        if not _USERNAME_RE.fullmatch(resolved):
+            raise ValueError("invalid username")
+        return resolved
+
+    @staticmethod
+    def validate_job_id(job_id: str) -> str:
+        if not _JOB_ID_RE.fullmatch(job_id):
+            raise ValueError("job_id must be a numeric Slurm job or array task ID")
+        return job_id
+
+    @staticmethod
+    def validate_lookback(since: str) -> str:
+        if not _LOOKBACK_RE.fullmatch(since):
+            raise ValueError("since must be 1-999 followed by m, h, d, or w")
+        seconds = int(since[:-1]) * _LOOKBACK_SECONDS[since[-1]]
+        if seconds > _MAX_LOOKBACK_SECONDS:
+            raise ValueError("since cannot exceed 90 days")
+        return since
+
+    def _jobs(self, command: list[str], source: str) -> list[dict[str, Any]]:
+        payload = _parse_payload(self.runner(command), command[0])
+        return [normalize_job(job, source) for job in payload.get("jobs", [])]
+
+    def list_jobs(
+        self,
+        username: str | None = None,
+        states: list[str] | None = None,
+        since: str = "24h",
+        limit: int = 50,
+        include_completed: bool = True,
+    ) -> dict[str, Any]:
+        user = self.resolve_username(username)
+        if not 1 <= limit <= 200:
+            raise ValueError("limit must be between 1 and 200")
+        requested_states = {state.upper() for state in states or []}
+        lookback = self.validate_lookback(since)
+
+        jobs = self._jobs(["squeue", "--json", "-u", user], "squeue")
+        sources = ["squeue"]
+        if include_completed:
+            jobs.extend(
+                self._jobs(
+                    ["sacct", "-X", "--json", "-u", user, "-S", _slurm_start_time(lookback)],
+                    "sacct",
+                )
+            )
+            sources.append("sacct")
+
+        merged: dict[str, dict[str, Any]] = {}
+        for job in jobs:
+            job_id = job["job_id"]
+            if not job_id or job.get("user") not in {None, user}:
+                continue
+            existing = merged.get(job_id)
+            if existing and existing["source"] == "squeue":
+                continue
+            merged[job_id] = job
+
+        filtered = [
+            job for job in merged.values()
+            if not requested_states or job["state"] in requested_states
+        ]
+        filtered.sort(
+            key=lambda job: (
+                job["state"] in ACTIVE_STATES,
+                job.get("submitted_at") or "",
+                job["job_id"],
+            ),
+            reverse=True,
+        )
+        filtered = filtered[:limit]
+        return {
+            "username": user,
+            "jobs": filtered,
+            "count": len(filtered),
+            "active_count": sum(job["state"] in ACTIVE_STATES for job in filtered),
+            "history_lookback": lookback if include_completed else None,
+            "fetched_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "sources": sources,
+        }
+
+    def get_job(self, job_id: str, username: str | None = None) -> dict[str, Any]:
+        user = self.resolve_username(username)
+        job_id = self.validate_job_id(job_id)
+        # Some Slurm versions fail instead of returning an empty list when -j
+        # names a completed job, so query the user's active queue and filter it.
+        active = self._jobs(["squeue", "--json", "-u", user], "squeue")
+        history = self._jobs(["sacct", "-X", "--json", "-u", user, "-j", job_id], "sacct")
+        matches = [
+            job for job in active + history
+            if job["job_id"] == job_id and job.get("user") in {None, user}
+        ]
+        if not matches:
+            raise ValueError(f"job {job_id} was not found for user {user}")
+        job = next((item for item in matches if item["source"] == "squeue"), matches[0])
+        return {"username": user, "job": job}
+
+    def get_job_usage(self, job_id: str, username: str | None = None) -> dict[str, Any]:
+        user = self.resolve_username(username)
+        job_id = self.validate_job_id(job_id)
+        payload = _parse_payload(
+            self.runner(["sacct", "--json", "-u", user, "-j", job_id]),
+            "sacct",
+        )
+        matching = [
+            job for job in payload.get("jobs", [])
+            if _job_id(job) == job_id and _user_name(job.get("user")) in {None, user}
+        ]
+        if not matching:
+            raise ValueError(f"job {job_id} was not found for user {user}")
+        raw_job = matching[0]
+        steps = []
+        for step in raw_job.get("steps", []):
+            tres = step.get("tres") if isinstance(step.get("tres"), dict) else {}
+            steps.append({
+                "step_id": step.get("step", {}).get("id") if isinstance(step.get("step"), dict) else None,
+                "name": step.get("step", {}).get("name") if isinstance(step.get("step"), dict) else None,
+                "state": _state(step.get("state")),
+                "elapsed": _duration(step.get("time", {}).get("elapsed")) if isinstance(step.get("time"), dict) else None,
+                "tasks": _number(step.get("tasks", {}).get("count")) if isinstance(step.get("tasks"), dict) else None,
+                "allocated": _tres(tres.get("allocated")),
+                "maximum": _tres(tres.get("requested", {}).get("max")) if isinstance(tres.get("requested"), dict) else {},
+                "average": _tres(tres.get("requested", {}).get("average")) if isinstance(tres.get("requested"), dict) else {},
+                "consumed": _tres(tres.get("consumed", {}).get("total")) if isinstance(tres.get("consumed"), dict) else {},
+            })
+        return {
+            "username": user,
+            "job": normalize_job(raw_job, "sacct"),
+            "steps": steps,
+            "note": "Usage fields depend on the accounting data collected by this cluster.",
+        }

--- a/NCSA/mcp_servers/slurm_server/tests/fixtures/sacct.json
+++ b/NCSA/mcp_servers/slurm_server/tests/fixtures/sacct.json
@@ -1,0 +1,56 @@
+{
+  "jobs": [
+    {
+      "job_id": 41001,
+      "name": "gpu-train",
+      "user": "student1",
+      "partition": "gpu",
+      "state": {"current": ["RUNNING"], "reason": "None"},
+      "time": {"submission": 1780000000, "start": 1780000060, "elapsed": 120}
+    },
+    {
+      "job_id": 40999,
+      "name": "preprocess",
+      "user": "student1",
+      "account": "class",
+      "partition": "cpu",
+      "state": {"current": ["COMPLETED"], "reason": "None"},
+      "allocation_nodes": 1,
+      "required": {"CPUs": 2},
+      "time": {"submission": 1779990000, "start": 1779990060, "end": 1779990120, "elapsed": 60},
+      "exit_code": {"return_code": {"set": true, "infinite": false, "number": 0}, "signal": {"id": {"set": false, "infinite": false, "number": 0}}},
+      "stdout": "/home/student1/project/slurm-40999.out",
+      "stderr": "/home/student1/project/slurm-40999.err",
+      "working_directory": "/home/student1/project",
+      "steps": [
+        {
+          "step": {"id": "40999.batch", "name": "batch"},
+          "state": ["COMPLETED"],
+          "time": {"elapsed": 60},
+          "tasks": {"count": 1},
+          "tres": {
+            "allocated": [{"type": "cpu", "name": "", "count": 2}],
+            "requested": {"max": [{"type": "mem", "name": "", "count": 1024}], "average": []},
+            "consumed": {"total": []}
+          }
+        }
+      ]
+    },
+    {
+      "job_id": 40000,
+      "name": "other-user",
+      "user": "student2",
+      "state": {"current": ["FAILED"], "reason": "None"},
+      "time": {"submission": 1779980000, "elapsed": 1}
+    },
+    {
+      "job_id": 39998,
+      "array": {"task_id": {"set": true, "infinite": false, "number": 3}},
+      "name": "array-task",
+      "user": "student1",
+      "state": {"current": ["FAILED"], "reason": "NonZeroExitCode"},
+      "time": {"submission": 1779970000, "elapsed": 2}
+    }
+  ],
+  "errors": []
+}

--- a/NCSA/mcp_servers/slurm_server/tests/fixtures/squeue.json
+++ b/NCSA/mcp_servers/slurm_server/tests/fixtures/squeue.json
@@ -1,0 +1,22 @@
+{
+  "jobs": [
+    {
+      "job_id": 41001,
+      "name": "gpu-train",
+      "user": "student1",
+      "account": "class",
+      "partition": "gpu",
+      "qos": "normal",
+      "state": {"current": ["RUNNING"], "reason": "None"},
+      "allocation_nodes": 1,
+      "nodes": "gpunode01",
+      "required": {"CPUs": 4},
+      "time": {"submission": 1780000000, "start": 1780000060, "elapsed": 120, "limit": {"set": true, "infinite": false, "number": 30}},
+      "tres": {"allocated": [{"type": "cpu", "name": "", "count": 4}, {"type": "gres", "name": "gpu", "count": 1}]},
+      "stdout": "/home/student1/project/slurm-41001.out",
+      "stderr": "/home/student1/project/slurm-41001.err",
+      "working_directory": "/home/student1/project"
+    }
+  ],
+  "errors": []
+}

--- a/NCSA/mcp_servers/slurm_server/tests/test_tracker.py
+++ b/NCSA/mcp_servers/slurm_server/tests/test_tracker.py
@@ -1,0 +1,86 @@
+import json
+import sys
+import unittest
+from pathlib import Path
+
+
+SERVER_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SERVER_DIR))
+
+from src.tracker import SlurmTracker  # noqa: E402
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+class FixtureRunner:
+    def __init__(self):
+        self.commands = []
+        self.squeue = (FIXTURES / "squeue.json").read_text()
+        self.sacct = (FIXTURES / "sacct.json").read_text()
+
+    def __call__(self, command):
+        self.commands.append(command)
+        if command[0] == "squeue":
+            return self.squeue
+        if command[0] == "sacct":
+            return self.sacct
+        raise AssertionError(f"unexpected command: {command}")
+
+
+class SlurmTrackerTests(unittest.TestCase):
+    def setUp(self):
+        self.runner = FixtureRunner()
+        self.tracker = SlurmTracker(identity_mode="explicit", runner=self.runner)
+
+    def test_list_merges_active_and_history_without_duplicates(self):
+        result = self.tracker.list_jobs("student1", since="7d")
+
+        self.assertEqual(
+            [job["job_id"] for job in result["jobs"]],
+            ["41001", "40999", "39998_3"],
+        )
+        self.assertEqual(result["active_count"], 1)
+        self.assertEqual(result["jobs"][0]["source"], "squeue")
+        self.assertEqual(result["jobs"][0]["resources"]["gres/gpu"], 1)
+        self.assertEqual(
+            self.runner.commands[1],
+            ["sacct", "-X", "--json", "-u", "student1", "-S", "now-7days"],
+        )
+
+    def test_list_filters_states(self):
+        result = self.tracker.list_jobs("student1", states=["completed"])
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(result["jobs"][0]["job_id"], "40999")
+
+    def test_get_job_prefers_active_record(self):
+        result = self.tracker.get_job("41001", "student1")
+        self.assertEqual(result["job"]["source"], "squeue")
+        self.assertEqual(result["job"]["state"], "RUNNING")
+
+    def test_get_usage_returns_step_metrics(self):
+        result = self.tracker.get_job_usage("40999", "student1")
+        self.assertEqual(result["steps"][0]["step_id"], "40999.batch")
+        self.assertEqual(result["steps"][0]["maximum"]["mem"], 1024)
+
+    def test_normalizes_array_task_ids(self):
+        result = self.tracker.get_job("39998_3", "student1")
+        self.assertEqual(result["job"]["job_id"], "39998_3")
+
+    def test_rejects_unsafe_identifiers_and_lookbacks(self):
+        with self.assertRaises(ValueError):
+            self.tracker.get_job("41001;rm -rf /", "student1")
+        with self.assertRaises(ValueError):
+            self.tracker.list_jobs("student1", since="yesterday")
+        with self.assertRaises(ValueError):
+            self.tracker.list_jobs("student1", since="91d")
+        with self.assertRaises(ValueError):
+            self.tracker.list_jobs("student1;id")
+
+    def test_fixture_is_valid_json(self):
+        self.assertIn("jobs", json.loads(self.runner.squeue))
+        self.assertIn("jobs", json.loads(self.runner.sacct))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add structured tools for active, completed, and historical jobs.
- Add an opt-in TUI sidebar with bounded polling.
- Keep tracking read-only and disabled by default.

## Validation
- All 7 Python tracker tests pass.
- TUI configuration loads successfully.