### PR TITLE
Fix blocking documentation queries

### DIFF
--- a/NCSA/mcp_servers/illinois_chat_server/README.md
+++ b/NCSA/mcp_servers/illinois_chat_server/README.md
@@ -8,8 +8,8 @@ clients connect to a URL such as `http://127.0.0.1:8000/mcp`.
 
 | Tool | Purpose |
 |------|---------|
-| `query_delta_documentation` | Query general Delta / HPC documentation (`Delta-Documentation`). |
-| `query_delta_ai_documentation` | Query Delta AI documentation (`DeltaAI-Documentation`). |
+| `query_delta_documentation` | Retrieve relevant general Delta / HPC documentation (`Delta-Documentation`) for the active hpcGPT model. |
+| `query_delta_ai_documentation` | Retrieve relevant Delta AI documentation (`DeltaAI-Documentation`) for the active hpcGPT model. |
 
 Each tool takes a single string argument: `query`.
 
@@ -28,8 +28,8 @@ pip install fastmcp requests pydantic rich-argparse
 1. Copy the example config and edit values:
 
 ```bash
-cd NCSA/mcp_servers/pychat_server
-cp config.example config.json
+cd NCSA/mcp_servers/illinois_chat_server
+cp example.config.json config.json
 ```
 
 2. Set at least `illinois_chat_url`, `illinois_chat_api_key`, and `illinois_chat_model` in `config.json`. Optional fields use defaults from `src/config.py` if omitted (`host`, `port`, `log_file`, `illinois_chat_system_prompt`).
@@ -54,7 +54,7 @@ python server.py
 python server.py -c /path/to/config.json -v
 ```
 
-On startup the server calls `verify_chat_connection()` (a minimal `retrieval_only` request) so misconfigured URLs or keys fail fast.
+On startup the server calls `verify_chat_connection()` (a minimal `retrieval_only` request) so misconfigured URLs or keys fail fast. Tool calls also use retrieval-only mode: Illinois Chat returns relevant contexts and the active hpcGPT model synthesizes the answer, avoiding a second upstream model generation and its latency.
 
 - **MCP endpoint:** `http://<host>:<port>/mcp` (FastMCP default Streamable HTTP path is `/mcp` unless overridden by FastMCP settings).
 
@@ -62,15 +62,15 @@ Point your MCP client at that URL with Streamable HTTP transport.
 
 ## Behavior notes
 
-- Upstream requests use `temperature` **0.3**, `stream: false`, and `retrieval_only: false` for normal tool calls.
-- Responses are normalized from several possible JSON shapes (`message`, OpenAI-style `choices[0].message.content`, or `response`).
+- Upstream requests use `temperature` **0.3**, `stream: false`, and `retrieval_only: true` for normal tool calls.
+- Retrieval contexts are returned as JSON for the active hpcGPT model to synthesize. Legacy response shapes (`message`, OpenAI-style `choices[0].message.content`, or `response`) remain supported.
 
 ## Project layout
 
 ```
-pychat_server/
+illinois_chat_server/
 ├── server.py          # MCP server and tools
-├── config.example     # Template for config.json
+├── example.config.json # Template for config.json
 ├── src/
 │   ├── config.py      # Pydantic config loading
 │   └── logging.py     # File logging and FastMCP log routing

--- a/NCSA/mcp_servers/illinois_chat_server/server.py
+++ b/NCSA/mcp_servers/illinois_chat_server/server.py
@@ -1,4 +1,6 @@
 import argparse
+import asyncio
+import json
 import logging
 import requests
 from fastmcp import FastMCP
@@ -6,6 +8,9 @@ from rich_argparse import RichHelpFormatter
 
 from src.config import Config, consolidate_config_and_args
 from src.logging import route_fastmcp_logs_to_root, setup_logging
+
+_REQUEST_TIMEOUT_SECONDS = 30
+
 
 class ChatMCP(FastMCP):
     """
@@ -33,9 +38,17 @@ class ChatMCP(FastMCP):
             "course_name": course_name,
             "stream": False,
             "temperature": 0.3,
-            "retrieval_only": False,
+            "retrieval_only": True,
         }
-        response = requests.post(self.illinois_chat_url, json=request_data)
+        try:
+            response = await asyncio.to_thread(
+                requests.post,
+                self.illinois_chat_url,
+                json=request_data,
+                timeout=_REQUEST_TIMEOUT_SECONDS,
+            )
+        except requests.RequestException as exc:
+            raise RuntimeError(f"Illinois Chat retrieval failed: {exc}") from exc
         if response.status_code != 200:
             raise RuntimeError(
                 f"Failed to send request to Illinois Chat API: "
@@ -43,6 +56,13 @@ class ChatMCP(FastMCP):
             )
         data = response.json()
         logging.info("Illinois Chat API Response: %s", data)
+        if "contexts" in data:
+            contexts = data["contexts"]
+            if not contexts:
+                return "No relevant Delta documentation context was found."
+            if isinstance(contexts, str):
+                return contexts
+            return json.dumps(contexts, ensure_ascii=True)
         if "message" in data:
             return data["message"]
         if (


### PR DESCRIPTION
## Why

The documentation MCP server makes a synchronous Illinois Chat request inside an async tool handler. It also requests a complete upstream LLM answer, even though hpcGPT performs the final answer synthesis afterward.

Direct MCP testing confirmed the impact:

- Idle MCP initialization took 0.008 seconds.
- Initialization during a 37-second documentation query was blocked for 36 seconds.
- Two concurrent documentation queries both reached the 60-second client timeout.
- Tool output contained `<think>` blocks, confirming redundant upstream generation.

Illinois Chat already supports retrieval-only requests that return contexts before model generation: [`chat.ts`](https://github.com/Center-for-AI-Innovation/Illinois-Chat/blob/main/apps/frontend/src/pages/api/chat-api/chat.ts#L271-L300).

## What Changed

- Set `retrieval_only: true`.
- Run `requests.post()` through `asyncio.to_thread()` so it does not block FastMCP.
- Add a 30-second upstream timeout.
- Return retrieved contexts for hpcGPT to synthesize.

## Validation

- Python syntax validation passes.
- Direct MCP tests reproduced and isolated the production blocking behavior.