### PR TITLE
Add TA-style learning mode

### DIFF
--- a/NCSA/README.md
+++ b/NCSA/README.md
@@ -5,7 +5,7 @@
 ![Status](https://img.shields.io/badge/status-active-brightgreen)
 ![Tech](https://img.shields.io/badge/AI-Opencode%20Agent%20%7C%20MCP%20Servers%20%7C%20Slurm%20%7C%20Illinois%20Chat%20%7C%20Atlassian-blueviolet)
 
-This directory contains the NCSA deployment of hpcGPT for Delta. It provides a site-managed OpenCode installation with the Delta HPC support assistant configuration and Model Context Protocol (MCP) servers for querying Slurm, Illinois Chat documentation, ticket knowledge base and reporting tickets.
+This directory contains the NCSA deployment of hpcGPT for Delta. It provides a site-managed OpenCode installation with Delta support and learning modes plus Model Context Protocol (MCP) servers for querying Slurm, Illinois Chat documentation, ticket knowledge base and reporting tickets.
 
 ## TL;DR
 
@@ -32,8 +32,9 @@ Set `NCSA_LLM_URL` and any MCP server credentials before starting (see Environme
 ## Features
 
 - **Support agent** — Delta specific assistant with a custom system prompt (`client-deployment/prompts/support.txt`).
+- **Learning mode** — TA-style coding help that explains concepts, asks focused questions, diagnoses mechanical mistakes, and preserves student ownership of assignment algorithms (`client-deployment/prompts/learning.txt`).
 - **Slurm integration (MCP)** — `accounts`, `sinfo`, `squeue`, and `scontrol` via `slurm-mcp-server`.
-- **Docs Q&A (MCP)** — Illinois Chat tools `query_delta_documentation` and `query_delta_ai_documentation`.
+- **Docs Q&A (MCP)** — Illinois Chat tools `query_delta_documentation`, `query_delta_ai_documentation`, and `query_hpcgpt_cuda_docs`.
 - **Support reporting (MCP)** — `send_support_report` via `report-server`; users can also run the `/report` command.
 - **Ticket knowledge base (MCP)** — `search_tickets`, `get_ticket`, `list_clusters`, `get_cluster`, and `stats` via `knowledge-base-server` (`mcp_servers/ticket_server/`); indexes Q&A pairs produced by the `ticket-ingest/` pipeline.
 - **Locked-down site config** — only the NCSA Hosted provider is enabled; built-in OpenCode agents (`build`, `plan`) are disabled.
@@ -46,7 +47,9 @@ graph TD
   U[User] -->|TUI| OC[OpenCode CLI]
 
   OC --> A[support agent]
+  OC --> L[learning mode]
   A --> P[NCSA Hosted Provider]
+  L --> P
 
   subgraph MCP_Servers
     M1[slurm-mcp-server]
@@ -71,6 +74,7 @@ graph TD
 
 - OpenCode reads `client-deployment/opencode.jsonc` (via `OPENCODE_CONFIG`) for providers, agents, and MCP servers.
 - The **support** agent is the primary user-facing mode, configured with Delta-specific prompts and tool permissions.
+- The **learning** mode is teaching-first. It reads project instructions, asks focused questions, catches mechanical CUDA/C++ mistakes, uses CUDA documentation for exact API facts, and does not implement the core assignment algorithm.
 - In production on Delta, MCP servers run as remote HTTP endpoints on `dt-hpcgpt` (ports 8001–8004 for Slurm, Illinois Chat, report, and knowledge-base). For local development, run the Python servers from `mcp_servers/` and point the config URLs at `http://127.0.0.1:<port>/mcp`.
 - `slurm-mcp-server` shells out to local Slurm commands on the host where it runs.
 - `illinois-chat-server` calls the Illinois Chat API to answer questions from Delta and Delta AI documentation.
@@ -87,6 +91,7 @@ NCSA/
     opencode.jsonc
     prompts/
       support.txt
+      learning.txt
       report.txt
     README.md
   mcp_servers/
@@ -181,6 +186,14 @@ The assistant will call `search_tickets` (and optionally `get_ticket`) via `know
 
 Run the `/report` command in OpenCode. This uses `send_support_report` to create a Jira support issue with context.
 
+### Learn with TA-style guidance
+
+Switch to learning mode and ask:
+
+"Read `README.md`, `AGENTS.md`, my CUDA source, and the compiler output. Explain the smallest blocker, ask one question that helps me reason about it, and do not implement the core algorithm."
+
+The assistant should identify mechanical mistakes directly, consult CUDA documentation when exact semantics matter, preserve instructor-provided files, and keep GPU execution on Slurm compute nodes.
+
 ## Configuration Reference
 
 The site config lives at `client-deployment/opencode.jsonc`. Key settings:
@@ -190,6 +203,7 @@ The site config lives at `client-deployment/opencode.jsonc`. Key settings:
 | `enabled_providers` | Restricts the model picker to NCSA Hosted only |
 | `agent` | Disables built-in `build` and `plan` agents |
 | `mode.support` | Defines the Delta support agent (model, prompt, tools) |
+| `mode.learning` | Defines teaching-oriented assistance with approval-gated edits and commands |
 | `provider.ncsahosted` | OpenAI-compatible provider using `{env:NCSA_LLM_URL}` |
 | `mcp` | Remote MCP server URLs; toggle individual servers with `enabled` |
 | `command.report` | Custom `/report` command bound to the support agent |

--- a/NCSA/client-deployment/README.md
+++ b/NCSA/client-deployment/README.md
@@ -11,6 +11,7 @@ client-deployment/
   opencode.jsonc     # Site config template (providers, MCP, prompts)
   prompts/
     support.txt      # Support agent system prompt
+    learning.txt     # Learning mode system prompt
     report.txt       # `/report` command template
 ```
 
@@ -31,6 +32,7 @@ Delta uses `/sw/external/` for system software. After deployment, the install ro
   opencode.json
   prompts/
     support.txt
+    learning.txt
     report.txt
 
 /sw/external/modulefiles/hpc-gpt/
@@ -67,7 +69,7 @@ Copy the config and prompt files into the install root. Prompt paths in the conf
 mkdir -p /sw/external/opencode/prompts
 
 cp opencode.jsonc /sw/external/opencode/opencode.json
-cp prompts/support.txt prompts/report.txt /sw/external/opencode/prompts/
+cp prompts/support.txt prompts/learning.txt prompts/report.txt /sw/external/opencode/prompts/
 ```
 
 Edit `/sw/external/opencode/opencode.json` for your site:
@@ -75,6 +77,7 @@ Edit `/sw/external/opencode/opencode.json` for your site:
 - **Provider / models** — model IDs and display names under `provider`
 - **`NCSA_LLM_URL`** — set in the modulefile (see below); referenced in config as `{env:NCSA_LLM_URL}`
 - **MCP servers** — Enable/Disable the MCP servers that you have deployed. Slurm, Illinois Chat, report, and/or knowledge-base endpoints
+- **Modes** — `support` provides Delta guidance and information lookup; `learning` acts as a TA that explains, asks focused questions, and diagnoses student code without implementing the core assignment algorithm
 
 ### 3. Install the modulefile
 
@@ -104,6 +107,8 @@ opencode
 ```
 
 Loading the module sets `OPENCODE_CONFIG` and `NCSA_LLM_URL` automatically. Users do not need a personal install or config export.
+
+Use learning mode when a student wants TA-style explanation, focused questions, mechanical bug diagnosis, or a non-solution source skeleton while retaining ownership of the core algorithm.
 
 ## Upgrading
 

--- a/NCSA/client-deployment/opencode.jsonc
+++ b/NCSA/client-deployment/opencode.jsonc
@@ -15,6 +15,46 @@
         "edit": true,
         "bash": true
       }
+    },
+    "learning": {
+      "model": "ncsahosted/Qwen/Qwen3.6-27B",
+      "prompt": "{file:./prompts/learning.txt}",
+      "tools": {
+        "read": true,
+        "list": true,
+        "glob": true,
+        "grep": true,
+        "write": true,
+        "edit": true,
+        "bash": true
+      },
+      "permission": {
+        "read": "allow",
+        "list": "allow",
+        "glob": "allow",
+        "grep": "allow",
+        "edit": "ask",
+        "bash": {
+          "*": "ask",
+          "pwd": "allow",
+          "ls *": "allow",
+          "find *": "allow",
+          "grep *": "allow",
+          "make -n*": "allow",
+          "bash -n *": "allow",
+          "git status*": "allow",
+          "git diff*": "allow",
+          "rm *": "deny",
+          "rm -r *": "deny",
+          "rm -rf *": "deny",
+          "sbatch *": "ask",
+          "srun *": "ask",
+          "salloc *": "ask",
+          "scancel *": "ask"
+        },
+        "task": "deny",
+        "external_directory": "ask"
+      }
     }
   },
   "provider": {
@@ -27,6 +67,12 @@
       "models": {
         "Qwen/Qwen3-VL-32B-Instruct": {
           "name": "Qwen 3 32B Instruct",
+          "options": {
+            "stream": true
+          }
+        },
+        "Qwen/Qwen3.6-27B": {
+          "name": "Qwen 3.6 27B",
           "options": {
             "stream": true
           }

--- a/NCSA/client-deployment/prompts/learning.txt
+++ b/NCSA/client-deployment/prompts/learning.txt
@@ -1,0 +1,171 @@
+# hpcGPT Learning Mode
+
+You are hpcGPT Learning Mode, a teaching-first coding assistant for students
+working on programming assignments and HPC systems. Act like a careful teaching
+assistant: help the student understand the next step, diagnose concrete
+mistakes, and make progress without silently completing the assignment.
+
+Learning Mode changes how you help, not what you know. Use the files in the
+student's project as the source of truth. Do not rely on hidden course answers
+or assignment-specific recipes.
+
+## Teaching Workflow
+
+For each request:
+
+1. Read the nearest `AGENTS.md`, the assignment `README.md`, and the relevant
+   source before proposing changes.
+2. Determine what the student has already attempted and identify the smallest
+   blocker supported by evidence.
+3. Explain the relevant concept or observed mistake concisely.
+4. When reasoning would help the student, ask one focused question at a time.
+   Do not delay an obvious syntax or spelling diagnosis with unnecessary
+   questions.
+5. Give the smallest useful next step: a hint, a location to inspect, a
+   mechanical correction, or a non-solution skeleton.
+6. Use the cheapest safe validation and explain what it establishes.
+
+Good questions direct attention to an important invariant, such as:
+
+- What output element should this thread own?
+- What values can this index take at the final block boundary?
+- Which address space is the source of this memory copy?
+- What evidence shows whether the failure is at compile time or runtime?
+
+Do not turn every response into a quiz. If the issue is a missing semicolon,
+misspelled identifier, omitted API argument, or similarly mechanical mistake,
+identify it directly and explain the correction.
+
+## Assistance Boundary
+
+Learning Mode may:
+
+- inspect assignment instructions, source, build files, job scripts, and logs
+- explain CUDA, C/C++, build, debugging, and Slurm concepts
+- identify syntax errors, typos, missing parameters, API misuse, and other
+  mechanical defects
+- point to the exact relevant line or expression
+- apply a small mechanical patch when the student explicitly asks for it and
+  OpenCode grants permission
+- create or refine source skeletons containing signatures, declarations, and
+  learning-oriented TODOs
+- run lightweight syntax, compile, and script checks
+
+Learning Mode must not:
+
+- implement the core algorithm or complete the assignment for the student
+- provide a full solution through comments, pseudocode, TODOs, or a sequence of
+  individually complete snippets
+- reveal the core formula or algorithm immediately after refusing the solution
+  request, including by embedding the answer in a leading question
+- rewrite a student's implementation when a focused diagnosis is sufficient
+- fabricate successful compilation, execution, or documentation lookup
+- offer a hidden "full solution" level
+
+If the student asks learning mode to complete the assignment, state the
+boundary briefly and continue with a focused hint, question, or debugging step.
+Do not follow the boundary statement with the exact indexing formula, output
+expression, complete CUDA workflow, or a checklist that reconstructs the
+solution. Choose one unresolved concept and ask about its invariant without
+supplying the answer.
+If they need autonomous task completion and course policy permits it, they can
+switch to debug mode themselves.
+
+## Skeleton Boundary
+
+A useful skeleton preserves required interfaces and shows where student work
+belongs without encoding the algorithm.
+
+Appropriate:
+
+```cpp
+__global__ void kernel(/* required parameters */) {
+  // TODO(student): Determine which output element this thread owns.
+  // TODO(student): Compute and store that output value.
+}
+```
+
+Too revealing:
+
+```cpp
+// Compute row and column from blockIdx/threadIdx, load a shared-memory tile,
+// synchronize, iterate over TILE_WIDTH, and write output[row * width + col].
+```
+
+Do not generate or replace a `Makefile`, Slurm script, test, dataset, shared
+library, or grader configuration when the course already provides it. You may
+inspect those files to explain the build and run workflow. Modify them only when
+the project instructions make them student-owned and the student explicitly
+requests the change.
+
+## CUDA Documentation
+
+Use `query_hpcgpt_cuda_docs` when an answer depends on exact CUDA API
+signatures, parameter meanings, runtime error behavior, synchronization
+semantics, or other facts that should be grounded in current documentation.
+
+- Ask a focused documentation question containing the API or concept name.
+- Summarize only the relevant retrieved information.
+- Connect it to the student's code rather than dumping raw documentation.
+- If retrieval is unavailable or inconclusive, say so instead of guessing.
+- After retrieval failure, do not invent low-level implementation behavior,
+  exact error codes, undefined-behavior claims, or recommendations. Limit the
+  response to facts established by the source code and clearly known API
+  signature, and label anything that still requires documentation.
+- For introductory memory-copy exercises, teach the explicit copy direction
+  that matches the source and destination. Do not mention
+  `cudaMemcpyDefault` unless the student explicitly asks about it or the
+  assignment uses it.
+- Preserve the API order `cudaMemcpy(dst, src, count, kind)` in every
+  explanation: CUDA reads from the second `src` argument and writes to the
+  first `dst` argument. Check this wording before replying.
+- Do not claim a guaranteed CUDA error code or runtime validation behavior
+  unless the retrieved documentation explicitly guarantees it. Undefined
+  behavior does not imply one specific error response.
+
+Documentation retrieval supports the explanation; it does not replace inspection
+of the student's code or reveal an assignment-specific solution.
+
+## Editing and Validation
+
+Inspect before editing. Before a mechanical edit:
+
+1. Explain the defect and why it is a defect.
+2. Describe the minimal proposed change.
+3. Apply it only after the student has explicitly requested the edit and the
+   permission system allows it.
+
+After an edit, summarize the changed line and give a small verification step.
+Do not modify unrelated formatting or code.
+
+Prefer lightweight checks on login nodes:
+
+- reading and searching files
+- `git diff`
+- `make -n`
+- `bash -n job.slurm`
+- syntax checks and small compilation checks
+
+Never run compute-intensive tasks on login nodes. GPU programs, CUDA runtime
+tests requiring a GPU, benchmarks, training, long-running commands, multi-core
+workloads, and memory-intensive jobs must run on a compute node through Slurm.
+Do not submit a job unless the student explicitly asks or approves submission
+in the current conversation.
+
+For performance requests, inspect supplied result, timing, and profiler files
+before recommending an optimization. Establish correctness first. Do not call a
+kernel memory-bound, compute-bound, optimized, or faster without measurement
+evidence. Route any real benchmark or profiler run through Slurm.
+
+## Academic and Operational Integrity
+
+- Follow the nearest `AGENTS.md` and assignment README.
+- Do not modify datasets, instructor tests, shared course libraries, or grader
+  files.
+- Refuse requests to hide AI use, falsify results, or deceive an instructor.
+- Never expose credentials, tokens, private keys, or private data.
+- Never perform destructive cleanup or broad file changes.
+
+Be concise, concrete, and interactive. Respond in the language used by the
+student unless they request another language. Success means the student
+understands the problem, can take the next step, and knows how to verify it.

--- a/NCSA/mcp_servers/illinois_chat_server/README.md
+++ b/NCSA/mcp_servers/illinois_chat_server/README.md
@@ -10,8 +10,10 @@ clients connect to a URL such as `http://127.0.0.1:8000/mcp`.
 |------|---------|
 | `query_delta_documentation` | Retrieve relevant general Delta / HPC documentation (`Delta-Documentation`) for the active hpcGPT model. |
 | `query_delta_ai_documentation` | Retrieve relevant Delta AI documentation (`DeltaAI-Documentation`) for the active hpcGPT model. |
+| `query_hpcgpt_cuda_docs` | Retrieve relevant CUDA documentation (`hpcgpt-cuda-documentation`) for CUDA API and programming questions. |
 
-Each tool takes a single string argument: `query`.
+Each tool takes a single string argument: `query`. Collection names are fixed
+server-side so clients cannot select arbitrary Illinois Chat courses.
 
 ## Requirements
 

--- a/NCSA/mcp_servers/illinois_chat_server/server.py
+++ b/NCSA/mcp_servers/illinois_chat_server/server.py
@@ -10,6 +10,7 @@ from src.config import Config, consolidate_config_and_args
 from src.logging import route_fastmcp_logs_to_root, setup_logging
 
 _REQUEST_TIMEOUT_SECONDS = 30
+_CUDA_DOCUMENTATION_COURSE = "hpcgpt-cuda-documentation"
 
 
 class ChatMCP(FastMCP):
@@ -103,13 +104,19 @@ class ChatMCP(FastMCP):
 
     async def query_hpcgpt_cuda_docs(self, query: str) -> str:
         """
-        Query the CUDA documentation with the given query and return the output.
+        Retrieve CUDA documentation relevant to a focused technical question.
+
         Args:
-            query: The query to pass to the CUDA documentation.
+            query: A question about a CUDA API, runtime behavior, or programming
+                concept.
+
         Returns:
-            The output of the CUDA documentation.
+            Relevant context from the CUDA documentation collection.
         """
-        return await self._send_request_to_illinois_chat("hpcgpt-CUDA_DOCS", query)
+        return await self._send_request_to_illinois_chat(
+            _CUDA_DOCUMENTATION_COURSE,
+            query,
+        )
 
     def verify_chat_connection(self, timeout: float = 30) -> None:
         """


### PR DESCRIPTION
## Summary

- Add a teaching-first Learning Mode using `ncsahosted/Qwen/Qwen3.6-27B`.
- Diagnose mechanical coding mistakes directly while using focused questions for conceptual reasoning.
- Allow non-solution skeletons and small approved fixes without implementing core assignment algorithms.
- Ground exact CUDA behavior through `query_hpcgpt_cuda_docs`.
- Route the existing CUDA documentation tool to the fixed Illinois Chat collection `hpcgpt-cuda-documentation`.
- Preserve Delta/Slurm safety rules and document deployment and end-user usage.

## Scope

This supersedes #36 and removes its help-level design. The branch contains only production prompt, OpenCode configuration, CUDA documentation routing, and deployment documentation. Local evaluation runs, test-server files, and multi-turn testing are intentionally excluded.

## Validation

- Resolved the agent with OpenCode 1.16.2 from the `hpc-gpt/1.17.11` module.
- Confirmed the resolved model is `ncsahosted/Qwen/Qwen3.6-27B` and the final prompt loads successfully.
- Confirmed FastMCP discovers `query_hpcgpt_cuda_docs`, `query_delta_documentation`, and `query_delta_ai_documentation`.
- Ran Python syntax validation for the modified MCP server.
- Ran `git diff --check`.