### PR TITLE
Fix CUDA documentation course name

### DIFF
--- a/NCSA/mcp_servers/illinois_chat_server/README.md
+++ b/NCSA/mcp_servers/illinois_chat_server/README.md
@@ -10,7 +10,7 @@ clients connect to a URL such as `http://127.0.0.1:8000/mcp`.
 |------|---------|
 | `query_delta_documentation` | Retrieve relevant general Delta / HPC documentation (`Delta-Documentation`) for the active hpcGPT model. |
 | `query_delta_ai_documentation` | Retrieve relevant Delta AI documentation (`DeltaAI-Documentation`) for the active hpcGPT model. |
-| `query_hpcgpt_cuda_docs` | Retrieve relevant CUDA documentation (`hpcgpt-cuda-documentation`) for CUDA API and programming questions. |
+| `query_hpcgpt_cuda_docs` | Retrieve relevant CUDA documentation (`hpcgpt-CUDA_DOCS`) for CUDA API and programming questions. |
 
 Each tool takes a single string argument: `query`. Collection names are fixed
 server-side so clients cannot select arbitrary Illinois Chat courses.

--- a/NCSA/mcp_servers/illinois_chat_server/server.py
+++ b/NCSA/mcp_servers/illinois_chat_server/server.py
@@ -10,7 +10,6 @@ from src.config import Config, consolidate_config_and_args
 from src.logging import route_fastmcp_logs_to_root, setup_logging
 
 _REQUEST_TIMEOUT_SECONDS = 30
-_CUDA_DOCUMENTATION_COURSE = "hpcgpt-cuda-documentation"
 
 
 class ChatMCP(FastMCP):
@@ -114,7 +113,7 @@ class ChatMCP(FastMCP):
             Relevant context from the CUDA documentation collection.
         """
         return await self._send_request_to_illinois_chat(
-            _CUDA_DOCUMENTATION_COURSE,
+            "hpcgpt-CUDA_DOCS",
             query,
         )
 

--- a/NCSA/mcp_servers/illinois_chat_server/server.py
+++ b/NCSA/mcp_servers/illinois_chat_server/server.py
@@ -112,10 +112,7 @@ class ChatMCP(FastMCP):
         Returns:
             Relevant context from the CUDA documentation collection.
         """
-        return await self._send_request_to_illinois_chat(
-            "hpcgpt-CUDA_DOCS",
-            query,
-        )
+        return await self._send_request_to_illinois_chat("hpcgpt-CUDA_DOCS", query)
 
     def verify_chat_connection(self, timeout: float = 30) -> None:
         """


### PR DESCRIPTION
## Summary
- route CUDA documentation queries directly to the existing `hpcgpt-CUDA_DOCS` Illinois Chat course
- remove the unnecessary course-name constant
- update the MCP server documentation with the exact course identifier

## Validation
- `python -m py_compile NCSA/mcp_servers/illinois_chat_server/server.py`
- `git diff --check`