### PR TITLE
Limit Illinois Chat retrieval contexts

### DIFF
--- a/NCSA/mcp_servers/illinois_chat_server/README.md
+++ b/NCSA/mcp_servers/illinois_chat_server/README.md
@@ -64,7 +64,7 @@ Point your MCP client at that URL with Streamable HTTP transport.
 
 ## Behavior notes
 
-- Upstream requests use `temperature` **0.3**, `stream: false`, and `retrieval_only: true` for normal tool calls.
+- Upstream requests use `temperature` **0.3**, `stream: false`, `retrieval_only: true`, and `top_n: 10` for normal tool calls.
 - Retrieval contexts are returned as JSON for the active hpcGPT model to synthesize. Legacy response shapes (`message`, OpenAI-style `choices[0].message.content`, or `response`) remain supported.
 
 ## Project layout

--- a/NCSA/mcp_servers/illinois_chat_server/server.py
+++ b/NCSA/mcp_servers/illinois_chat_server/server.py
@@ -41,6 +41,7 @@ class ChatMCP(FastMCP):
             "stream": False,
             "temperature": 0.3,
             "retrieval_only": True,
+            "top_n": 10,
         }
         try:
             response = await asyncio.to_thread(


### PR DESCRIPTION
## Summary
- send `top_n: 10` with normal Illinois Chat documentation retrieval requests
- keep startup connectivity verification unchanged
- document the retrieval limit

Existing MCP tools retain their current `query`-only interface. The limit is local to `_send_request_to_illinois_chat`, so the model does not need to choose it.

## Dependency
This field will affect response size after [Illinois-Chat PR #111](https://github.com/Center-for-AI-Innovation/Illinois-Chat/pull/111) is merged and deployed. Older Illinois Chat deployments ignore the field.

## Validation
- `python -m py_compile NCSA/mcp_servers/illinois_chat_server/server.py`
- inline mocked request check confirmed tool payloads contain `top_n: 10` and startup verification omits `top_n`
- `git diff --check`

No test files are included in this PR.