### PR TITLE
Limit Illinois Chat retrieval contexts

### DIFF
--- a/NCSA/mcp_servers/illinois_chat_server/server.py
+++ b/NCSA/mcp_servers/illinois_chat_server/server.py
@@ -90,6 +90,7 @@ class ChatMCP(FastMCP):
             "stream": False,
             "temperature": 0.3,
             "retrieval_only": True,
+            "top_n": 10,
         }
         try:
             response = await asyncio.to_thread(


### PR DESCRIPTION
## Summary

- Request 10 contexts for normal Illinois Chat documentation retrieval.
- Leave startup/course verification requests unchanged.

Depends on Center-for-AI-Innovation/Illinois-Chat#147.

## Evidence

Production documentation calls currently return 100 contexts (239-307 KB). OpenCode truncated a 256 KB tool result and needed three extra Python/bash calls to inspect it. Limiting retrieval to 10 contexts reduces response size, model context use, and follow-up tool calls.

## Validation

- `python -m py_compile NCSA/mcp_servers/illinois_chat_server/server.py`: passed
- `git diff --check`: passed
