### PR TITLE
Make Learning Mode the default agent

### DIFF
--- a/NCSA/client-deployment/opencode.jsonc
+++ b/NCSA/client-deployment/opencode.jsonc
@@ -2,7 +2,7 @@
   "$schema": "https://opencode.ai/config.json",
   "autoupdate": false,
   "enabled_providers": ["ncsahosted", "lumen"],
-  "default_agent": "support",
+  "default_agent": "learning",
   "agent": {
     "build": { "disable": true },
     "plan": { "disable": true },


### PR DESCRIPTION
## Summary

- Set `default_agent` to `learning` explicitly.
- Keep Support and Debug modes available for manual selection.

This removes dependence on UI/agent ordering. Merge #51 first.

## Validation

- OpenCode resolved `default_agent: learning` through `opencode debug config --pure`.
- `git diff --check` passed.
