### PR TITLE
Add conversation feedback TUI

### DIFF
--- a/NCSA/client-deployment/README.md
+++ b/NCSA/client-deployment/README.md
@@ -114,6 +114,9 @@ Update the template for your site:
 | `OPENCODE_CONFIG` | Path to your site config (e.g. `/sw/external/opencode/delta-opencode.json`) |
 | `OPENCODE_TUI_CONFIG` | Path to the site TUI config (e.g. `/sw/external/opencode/tui.jsonc`) |
 | `NCSA_LLM_URL` | Base URL for your hosted OpenAI-compatible model endpoint |
+| `HPCGPT_FEEDBACK_EMAIL` | Site feedback recipient used by the TUI plugin |
+
+The feedback plugin requires a working system `mail` command on the login nodes.
 
 ## End user usage
 
@@ -124,11 +127,11 @@ module load hpc-gpt/1.15.13
 opencode
 ```
 
-Loading the module sets `OPENCODE_CONFIG`, `OPENCODE_TUI_CONFIG`, and `NCSA_LLM_URL` automatically. Users do not need a personal install or config export.
+Loading the module sets `OPENCODE_CONFIG`, `OPENCODE_TUI_CONFIG`, `NCSA_LLM_URL`, and `HPCGPT_FEEDBACK_EMAIL` automatically. Users do not need a personal install or config export.
 
 Run `/jobs` to enable the Slurm sidebar and load status once. Click `[Refresh]` or run `/jobs-refresh` for another update. The sidebar performs no background polling.
 
-Run `/feedback` to select a category, enter a short comment, and explicitly confirm attachment of the visible conversation. Submission makes one request to `HPCGPT_FEEDBACK_URL`; no request is made until the user confirms. The deployment must set that variable after choosing a feedback service.
+Run `/feedback` to select a category, enter a short comment, and explicitly confirm attachment of the full OpenCode session. The importable session export is limited to 5 MiB and may contain reasoning, tool output, and file content. No email is sent until the user confirms. The plugin uses the local `mail` command and the recipient configured by `HPCGPT_FEEDBACK_EMAIL`; it does not invoke the LLM or ticket-reporting MCP server.
 
 Use learning mode when a student wants TA-style explanation, focused questions, mechanical bug diagnosis, or a non-solution source skeleton while retaining ownership of the core algorithm.
 

--- a/NCSA/client-deployment/README.md
+++ b/NCSA/client-deployment/README.md
@@ -12,6 +12,7 @@ client-deployment/
   tui.jsonc          # TUI config that loads site interface plugins
   plugins/
     slurm-sidebar/   # Opt-in, no-LLM Slurm status display
+    feedback/        # Direct conversation feedback dialog
   prompts/
     support.txt      # Support agent system prompt
     debug.txt        # Debug mode system prompt
@@ -26,6 +27,7 @@ client-deployment/
 | `opencode.jsonc` | Site config: provider, models, MCP server URLs, permissions, and prompt references |
 | `tui.jsonc` | Site TUI config loaded through `OPENCODE_TUI_CONFIG` |
 | `plugins/slurm-sidebar/` | Read-only sidebar that runs local Slurm commands only on user-requested refresh |
+| `plugins/feedback/` | No-LLM feedback dialog with an explicitly confirmed conversation attachment |
 | `prompts/` | Prompt files referenced by `opencode.jsonc` via `{file:./prompts/...}` |
 
 ## Target site layout
@@ -39,6 +41,7 @@ Delta uses `/sw/external/` for system software. After deployment, the install ro
   tui.jsonc
   plugins/
     slurm-sidebar/
+    feedback/
   prompts/
     support.txt
     debug.txt
@@ -82,6 +85,7 @@ mkdir -p /sw/external/opencode/plugins
 cp opencode.jsonc /sw/external/opencode/opencode.json
 cp tui.jsonc /sw/external/opencode/tui.jsonc
 cp -R plugins/slurm-sidebar /sw/external/opencode/plugins/
+cp -R plugins/feedback /sw/external/opencode/plugins/
 cp prompts/support.txt prompts/debug.txt prompts/learning.txt prompts/report.txt /sw/external/opencode/prompts/
 ```
 
@@ -123,6 +127,8 @@ opencode
 Loading the module sets `OPENCODE_CONFIG`, `OPENCODE_TUI_CONFIG`, and `NCSA_LLM_URL` automatically. Users do not need a personal install or config export.
 
 Run `/jobs` to enable the Slurm sidebar and load status once. Click `[Refresh]` or run `/jobs-refresh` for another update. The sidebar performs no background polling.
+
+Run `/feedback` to select a category, enter a short comment, and explicitly confirm attachment of the visible conversation. Submission makes one request to `HPCGPT_FEEDBACK_URL`; no request is made until the user confirms. The deployment must set that variable after choosing a feedback service.
 
 Use learning mode when a student wants TA-style explanation, focused questions, mechanical bug diagnosis, or a non-solution source skeleton while retaining ownership of the core algorithm.
 

--- a/NCSA/client-deployment/delta-module.lua
+++ b/NCSA/client-deployment/delta-module.lua
@@ -22,6 +22,7 @@ prepend_path("PATH", pathJoin(root, "bin"))
 setenv("OPENCODE_CONFIG", pathJoin(root, "delta-opencode.jsonc")) -- Set this to your own config file
 setenv("OPENCODE_TUI_CONFIG", pathJoin(root, "tui.jsonc"))
 setenv("NCSA_LLM_URL", "https://example.endpoint/v1") -- Set this to your own hosted model URL
+setenv("HPCGPT_FEEDBACK_EMAIL", "feedback@example.edu") -- Set this to the site feedback address
 
 if (mode() == "load") then
   -- LmodMsgRaw avoids LmodMessage's line-wrapping ("Fill"), which distorts ASCII art.

--- a/NCSA/client-deployment/plugins/feedback/index.tsx
+++ b/NCSA/client-deployment/plugins/feedback/index.tsx
@@ -191,11 +191,9 @@ const plugin: TuiPluginModule = {
           return (
             <box flexDirection="column" paddingTop={1}>
               <text fg={context.theme.current.text}>
-                <b>If you have issue</b>
+                <b>Having an issue?</b>
               </text>
-              <text fg={context.theme.current.info} onMouseUp={() => openFeedback(api, context.session_id)}>
-                /feedback
-              </text>
+              <text fg={context.theme.current.info}>/feedback</text>
             </box>
           )
         },

--- a/NCSA/client-deployment/plugins/feedback/index.tsx
+++ b/NCSA/client-deployment/plugins/feedback/index.tsx
@@ -193,7 +193,7 @@ const plugin: TuiPluginModule = {
               <text fg={context.theme.current.text}>
                 <b>Having an issue?</b>
               </text>
-              <text fg={context.theme.current.text}>/feedback</text>
+              <text fg={context.theme.current.textMuted}>/feedback</text>
             </box>
           )
         },

--- a/NCSA/client-deployment/plugins/feedback/index.tsx
+++ b/NCSA/client-deployment/plugins/feedback/index.tsx
@@ -193,7 +193,7 @@ const plugin: TuiPluginModule = {
               <text fg={context.theme.current.text}>
                 <b>Having an issue?</b>
               </text>
-              <text fg={context.theme.current.info}>/feedback</text>
+              <text fg={context.theme.current.text}>/feedback</text>
             </box>
           )
         },

--- a/NCSA/client-deployment/plugins/feedback/index.tsx
+++ b/NCSA/client-deployment/plugins/feedback/index.tsx
@@ -1,0 +1,207 @@
+import type { TuiPluginApi, TuiPluginModule } from "@opencode-ai/plugin/tui"
+
+const MAX_FEEDBACK_CHARS = 4_000
+const MAX_MESSAGES = 50
+const MAX_MESSAGE_CHARS = 2_400
+const REQUEST_TIMEOUT_MS = 10_000
+
+const categories = [
+  { title: "Helpful", value: "helpful", description: "The response worked well" },
+  { title: "Incorrect answer", value: "incorrect", description: "The response contains an error" },
+  { title: "Revealed too much", value: "answer-leak", description: "Learning mode provided too much solution code" },
+  { title: "Too restrictive", value: "too-restrictive", description: "The agent would not provide reasonable help" },
+  { title: "Tool failure", value: "tool-failure", description: "A command or tool did not work" },
+  { title: "Other", value: "other", description: "Another issue or suggestion" },
+] as const
+
+type FeedbackCategory = (typeof categories)[number]["value"]
+
+function clip(value: string) {
+  if (value.length <= MAX_MESSAGE_CHARS) return { value, truncated: false }
+  const marker = "\n...[truncated]...\n"
+  const side = Math.floor((MAX_MESSAGE_CHARS - marker.length) / 2)
+  return { value: `${value.slice(0, side)}${marker}${value.slice(-side)}`, truncated: true }
+}
+
+function transcript(api: TuiPluginApi, sessionID: string) {
+  const all = api.state.session.messages(sessionID).flatMap((message) => {
+    const content = api.state
+      .part(message.id)
+      .flatMap((part) =>
+        part.type === "text" && !part.synthetic && !part.ignored ? [part.text] : [],
+      )
+      .join("\n")
+      .trim()
+
+    if (!content) return []
+    return [{ id: message.id, role: message.role, created: message.time.created, content }]
+  })
+
+  const selected = all.length > MAX_MESSAGES ? [all[0], ...all.slice(-(MAX_MESSAGES - 1))] : all
+  let truncated = selected.length !== all.length
+  const messages = selected.map((message) => {
+    const content = clip(message.content)
+    truncated ||= content.truncated
+    return { ...message, content: content.value }
+  })
+
+  return { messages, truncated }
+}
+
+function currentSessionID(api: TuiPluginApi) {
+  const route = api.route.current
+  if (route.name !== "session" || !("params" in route)) return
+  return typeof route.params?.sessionID === "string" ? route.params.sessionID : undefined
+}
+
+function payload(api: TuiPluginApi, sessionID: string, category: FeedbackCategory, comment: string) {
+  const messages = api.state.session.messages(sessionID)
+  const assistant = [...messages].reverse().find((message) => message.role === "assistant")
+  const conversation = transcript(api, sessionID)
+
+  return {
+    version: 1,
+    category,
+    comment,
+    submitted_at: new Date().toISOString(),
+    client: { opencode_version: api.app.version },
+    session: {
+      id: sessionID,
+      title: api.state.session.get(sessionID)?.title,
+      agent: assistant?.agent,
+      mode: assistant?.role === "assistant" ? assistant.mode : undefined,
+      model:
+        assistant?.role === "assistant"
+          ? `${assistant.providerID}/${assistant.modelID}`
+          : undefined,
+    },
+    conversation: conversation.messages,
+    conversation_truncated: conversation.truncated,
+  }
+}
+
+async function submitFeedback(body: ReturnType<typeof payload>) {
+  const endpoint = process.env.HPCGPT_FEEDBACK_URL?.trim()
+  if (!endpoint) throw new Error("Feedback destination is not configured")
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+  try {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    })
+    if (!response.ok) throw new Error(`Feedback service returned HTTP ${response.status}`)
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function confirm(api: TuiPluginApi, sessionID: string, category: FeedbackCategory, comment: string) {
+  const body = payload(api, sessionID, category, comment)
+  const count = body.conversation.length
+  const suffix = body.conversation_truncated ? " (truncated)" : ""
+
+  api.ui.dialog.replace(() => (
+    <api.ui.DialogConfirm
+      title="Submit feedback"
+      message={`Attach ${count} visible user/assistant messages${suffix}? System prompts, reasoning, tool output, and files are excluded.`}
+      onCancel={() => api.ui.dialog.clear()}
+      onConfirm={() => {
+        api.ui.dialog.clear()
+        void submitFeedback(body)
+          .then(() => api.ui.toast({ variant: "success", title: "Feedback", message: "Feedback submitted." }))
+          .catch((cause) =>
+            api.ui.toast({
+              variant: "error",
+              title: "Feedback",
+              message: cause instanceof Error ? cause.message : String(cause),
+            }),
+          )
+      }}
+    />
+  ))
+}
+
+function askForComment(api: TuiPluginApi, sessionID: string, category: FeedbackCategory) {
+  api.ui.dialog.replace(() => (
+    <api.ui.DialogPrompt
+      title="Feedback"
+      placeholder="What should hpcGPT improve?"
+      onCancel={() => api.ui.dialog.clear()}
+      onConfirm={(value) => {
+        const comment = value.trim()
+        if (!comment) {
+          api.ui.toast({ variant: "error", title: "Feedback", message: "Please enter a short comment." })
+          return
+        }
+        if (comment.length > MAX_FEEDBACK_CHARS) {
+          api.ui.toast({
+            variant: "error",
+            title: "Feedback",
+            message: `Feedback must be ${MAX_FEEDBACK_CHARS} characters or fewer.`,
+          })
+          return
+        }
+        confirm(api, sessionID, category, comment)
+      }}
+    />
+  ))
+}
+
+function openFeedback(api: TuiPluginApi, sessionID?: string) {
+  if (!sessionID) {
+    api.ui.toast({ variant: "error", title: "Feedback", message: "Open a conversation before sending feedback." })
+    return
+  }
+
+  api.ui.dialog.replace(() => (
+    <api.ui.DialogSelect
+      title="Feedback category"
+      skipFilter={true}
+      options={[...categories]}
+      onSelect={(option) => askForComment(api, sessionID, option.value as FeedbackCategory)}
+    />
+  ))
+}
+
+const plugin: TuiPluginModule = {
+  id: "ncsa-feedback",
+  async tui(api) {
+    const unregister = api.keymap.registerLayer({
+      commands: [
+        {
+          title: "Send hpcGPT feedback",
+          name: "ncsa.feedback.submit",
+          desc: "Send feedback with the current conversation attached",
+          category: "Feedback",
+          namespace: "palette",
+          slashName: "feedback",
+          run: () => openFeedback(api, currentSessionID(api)),
+        },
+      ],
+    })
+    api.lifecycle.onDispose(unregister)
+
+    api.slots.register({
+      slots: {
+        sidebar_content(context) {
+          return (
+            <box flexDirection="column" paddingTop={1}>
+              <text fg={context.theme.current.text}>
+                <b>If you have issue</b>
+              </text>
+              <text fg={context.theme.current.info} onMouseUp={() => openFeedback(api, context.session_id)}>
+                /feedback
+              </text>
+            </box>
+          )
+        },
+      },
+    })
+  },
+}
+
+export default plugin

--- a/NCSA/client-deployment/plugins/feedback/index.tsx
+++ b/NCSA/client-deployment/plugins/feedback/index.tsx
@@ -1,9 +1,8 @@
 import type { TuiPluginApi, TuiPluginModule } from "@opencode-ai/plugin/tui"
 
+import { sendFeedback } from "./mail.js"
+
 const MAX_FEEDBACK_CHARS = 4_000
-const MAX_MESSAGES = 50
-const MAX_MESSAGE_CHARS = 2_400
-const REQUEST_TIMEOUT_MS = 10_000
 
 const categories = [
   { title: "Helpful", value: "helpful", description: "The response worked well" },
@@ -16,38 +15,6 @@ const categories = [
 
 type FeedbackCategory = (typeof categories)[number]["value"]
 
-function clip(value: string) {
-  if (value.length <= MAX_MESSAGE_CHARS) return { value, truncated: false }
-  const marker = "\n...[truncated]...\n"
-  const side = Math.floor((MAX_MESSAGE_CHARS - marker.length) / 2)
-  return { value: `${value.slice(0, side)}${marker}${value.slice(-side)}`, truncated: true }
-}
-
-function transcript(api: TuiPluginApi, sessionID: string) {
-  const all = api.state.session.messages(sessionID).flatMap((message) => {
-    const content = api.state
-      .part(message.id)
-      .flatMap((part) =>
-        part.type === "text" && !part.synthetic && !part.ignored ? [part.text] : [],
-      )
-      .join("\n")
-      .trim()
-
-    if (!content) return []
-    return [{ id: message.id, role: message.role, created: message.time.created, content }]
-  })
-
-  const selected = all.length > MAX_MESSAGES ? [all[0], ...all.slice(-(MAX_MESSAGES - 1))] : all
-  let truncated = selected.length !== all.length
-  const messages = selected.map((message) => {
-    const content = clip(message.content)
-    truncated ||= content.truncated
-    return { ...message, content: content.value }
-  })
-
-  return { messages, truncated }
-}
-
 function currentSessionID(api: TuiPluginApi) {
   const route = api.route.current
   if (route.name !== "session" || !("params" in route)) return
@@ -55,63 +22,39 @@ function currentSessionID(api: TuiPluginApi) {
 }
 
 function payload(api: TuiPluginApi, sessionID: string, category: FeedbackCategory, comment: string) {
-  const messages = api.state.session.messages(sessionID)
-  const assistant = [...messages].reverse().find((message) => message.role === "assistant")
-  const conversation = transcript(api, sessionID)
+  const info = api.state.session.get(sessionID)
+  if (!info) throw new Error("The current session is unavailable")
+  const uid = (process.env.USER?.trim() || "unknown")
+    .replace(/[^A-Za-z0-9._-]/g, "_")
+    .slice(0, 64)
 
   return {
-    version: 1,
+    uid: uid || "unknown",
     category,
     comment,
-    submitted_at: new Date().toISOString(),
-    client: { opencode_version: api.app.version },
-    session: {
-      id: sessionID,
-      title: api.state.session.get(sessionID)?.title,
-      agent: assistant?.agent,
-      mode: assistant?.role === "assistant" ? assistant.mode : undefined,
-      model:
-        assistant?.role === "assistant"
-          ? `${assistant.providerID}/${assistant.modelID}`
-          : undefined,
+    session_export: {
+      info,
+      messages: api.state.session.messages(sessionID).map((message) => ({
+        info: message,
+        parts: api.state.part(message.id),
+      })),
     },
-    conversation: conversation.messages,
-    conversation_truncated: conversation.truncated,
-  }
-}
-
-async function submitFeedback(body: ReturnType<typeof payload>) {
-  const endpoint = process.env.HPCGPT_FEEDBACK_URL?.trim()
-  if (!endpoint) throw new Error("Feedback destination is not configured")
-
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
-  try {
-    const response = await fetch(endpoint, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(body),
-      signal: controller.signal,
-    })
-    if (!response.ok) throw new Error(`Feedback service returned HTTP ${response.status}`)
-  } finally {
-    clearTimeout(timeout)
   }
 }
 
 function confirm(api: TuiPluginApi, sessionID: string, category: FeedbackCategory, comment: string) {
-  const body = payload(api, sessionID, category, comment)
-  const count = body.conversation.length
-  const suffix = body.conversation_truncated ? " (truncated)" : ""
+  const count = api.state.session.messages(sessionID).length
 
   api.ui.dialog.replace(() => (
     <api.ui.DialogConfirm
       title="Submit feedback"
-      message={`Attach ${count} visible user/assistant messages${suffix}? System prompts, reasoning, tool output, and files are excluded.`}
+      message={`Attach the full ${count}-message OpenCode session? It may include reasoning, tool output, and file content.`}
       onCancel={() => api.ui.dialog.clear()}
       onConfirm={() => {
         api.ui.dialog.clear()
-        void submitFeedback(body)
+        void Promise.resolve()
+          .then(() => payload(api, sessionID, category, comment))
+          .then(sendFeedback)
           .then(() => api.ui.toast({ variant: "success", title: "Feedback", message: "Feedback submitted." }))
           .catch((cause) =>
             api.ui.toast({

--- a/NCSA/client-deployment/plugins/feedback/mail.js
+++ b/NCSA/client-deployment/plugins/feedback/mail.js
@@ -1,0 +1,58 @@
+import { mkdtemp, rmdir, unlink, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const MAX_SESSION_EXPORT_BYTES = 5 * 1024 * 1024
+const MAIL_TIMEOUT_MS = 10_000
+
+export async function sendFeedback(feedback) {
+  const recipient = process.env.HPCGPT_FEEDBACK_EMAIL?.trim()
+  if (!recipient || !/^[^@\s]+@[^@\s]+$/.test(recipient)) {
+    throw new Error("Feedback email is not configured")
+  }
+
+  const session = JSON.stringify(feedback.session_export)
+  if (new TextEncoder().encode(session).byteLength > MAX_SESSION_EXPORT_BYTES) {
+    throw new Error("This session is too large to attach (5 MiB maximum)")
+  }
+
+  const directory = await mkdtemp(join(tmpdir(), "hpcgpt-feedback-"))
+  const attachment = join(directory, "hpcgpt-session.json")
+  try {
+    await writeFile(attachment, session, "utf8")
+    const child = Bun.spawn({
+      cmd: [
+        "mail",
+        "-s",
+        `hpcGPT Feedback [${feedback.uid}] [${feedback.category}]`,
+        "-a",
+        attachment,
+        recipient,
+      ],
+      stdin: "pipe",
+      stdout: "ignore",
+      stderr: "pipe",
+    })
+    child.stdin.write(`${feedback.comment}\n`)
+    child.stdin.end()
+
+    let timedOut = false
+    const timer = setTimeout(() => {
+      timedOut = true
+      child.kill()
+    }, MAIL_TIMEOUT_MS)
+    try {
+      const [code, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stderr).text(),
+      ])
+      if (timedOut) throw new Error("Feedback delivery timed out")
+      if (code !== 0) throw new Error(stderr.trim() || `mail exited with code ${code}`)
+    } finally {
+      clearTimeout(timer)
+    }
+  } finally {
+    await unlink(attachment).catch(() => {})
+    await rmdir(directory).catch(() => {})
+  }
+}

--- a/NCSA/client-deployment/plugins/feedback/package.json
+++ b/NCSA/client-deployment/plugins/feedback/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ncsa-feedback",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./tui": "./index.tsx"
+  },
+  "engines": {
+    "opencode": ">=1.17.0"
+  }
+}

--- a/NCSA/client-deployment/tui.jsonc
+++ b/NCSA/client-deployment/tui.jsonc
@@ -1,4 +1,4 @@
 {
   "$schema": "https://opencode.ai/tui.json",
-  "plugin": ["./plugins/slurm-sidebar"]
+  "plugin": ["./plugins/slurm-sidebar", "./plugins/feedback"]
 }


### PR DESCRIPTION
## Summary
- add a direct `/feedback` TUI flow with category, comment, and explicit full-session attachment consent
- show a static `/feedback` hint below the Slurm sidebar
- send the comment and native OpenCode session attachment with the local `mail` command
- configure the recipient with `HPCGPT_FEEDBACK_EMAIL` and the authorized sender with `HPCGPT_FEEDBACK_FROM` in the deployed Delta modulefile
- include the user ID and category in the email subject
- leave the existing report MCP and Jira ticket-reporting tool unchanged

## Deployment
- copy `plugins/feedback/` with the other TUI plugins
- deploy the configured feedback recipient and sender from `delta-module.lua`
- authorize the configured sender in the destination mailing list
- ensure the login nodes provide a working system `mail` command

## Validation
- submitted a real 50-message session through OpenCode 1.18.23 `/feedback`
- verified the `mail` arguments include `-r noreply@hpcgpt.ncsa.illinois.edu`, the expected recipient, subject, comment, and attachment using a fake executable; no real email was sent
- imported the captured attachment successfully with `opencode import`
- verified there is no diff under `NCSA/mcp_servers/report_server/`
- `git diff --check` passes