### PR TITLE
Configure authorized feedback sender

### DIFF
--- a/NCSA/client-deployment/README.md
+++ b/NCSA/client-deployment/README.md
@@ -115,6 +115,7 @@ Update the template for your site:
 | `OPENCODE_TUI_CONFIG` | Path to the site TUI config (e.g. `/sw/external/opencode/tui.jsonc`) |
 | `NCSA_LLM_URL` | Base URL for your hosted OpenAI-compatible model endpoint |
 | `HPCGPT_FEEDBACK_EMAIL` | Site feedback recipient used by the TUI plugin |
+| `HPCGPT_FEEDBACK_FROM` | Authorized sender used by the TUI plugin |
 
 The feedback plugin requires a working system `mail` command on the login nodes.
 
@@ -127,7 +128,7 @@ module load hpc-gpt/1.15.13
 opencode
 ```
 
-Loading the module sets `OPENCODE_CONFIG`, `OPENCODE_TUI_CONFIG`, `NCSA_LLM_URL`, and `HPCGPT_FEEDBACK_EMAIL` automatically. Users do not need a personal install or config export.
+Loading the module sets `OPENCODE_CONFIG`, `OPENCODE_TUI_CONFIG`, `NCSA_LLM_URL`, `HPCGPT_FEEDBACK_EMAIL`, and `HPCGPT_FEEDBACK_FROM` automatically. Users do not need a personal install or config export.
 
 Run `/jobs` to enable the Slurm sidebar and load status once. Click `[Refresh]` or run `/jobs-refresh` for another update. The sidebar performs no background polling.
 

--- a/NCSA/client-deployment/delta-module.lua
+++ b/NCSA/client-deployment/delta-module.lua
@@ -22,7 +22,8 @@ prepend_path("PATH", pathJoin(root, "bin"))
 setenv("OPENCODE_CONFIG", pathJoin(root, "delta-opencode.jsonc")) -- Set this to your own config file
 setenv("OPENCODE_TUI_CONFIG", pathJoin(root, "tui.jsonc"))
 setenv("NCSA_LLM_URL", "https://example.endpoint/v1") -- Set this to your own hosted model URL
-setenv("HPCGPT_FEEDBACK_EMAIL", "feedback@example.edu") -- Set this to the site feedback address
+setenv("HPCGPT_FEEDBACK_EMAIL", "feedback@example.edu") -- Set in the deployed modulefile
+setenv("HPCGPT_FEEDBACK_FROM", "noreply@example.edu") -- Set in the deployed modulefile
 
 if (mode() == "load") then
   -- LmodMsgRaw avoids LmodMessage's line-wrapping ("Fill"), which distorts ASCII art.

--- a/NCSA/client-deployment/plugins/feedback/mail.js
+++ b/NCSA/client-deployment/plugins/feedback/mail.js
@@ -7,8 +7,12 @@ const MAIL_TIMEOUT_MS = 10_000
 
 export async function sendFeedback(feedback) {
   const recipient = process.env.HPCGPT_FEEDBACK_EMAIL?.trim()
+  const sender = process.env.HPCGPT_FEEDBACK_FROM?.trim()
   if (!recipient || !/^[^@\s]+@[^@\s]+$/.test(recipient)) {
     throw new Error("Feedback email is not configured")
+  }
+  if (!sender || !/^[^@\s]+@[^@\s]+$/.test(sender)) {
+    throw new Error("Feedback sender is not configured")
   }
 
   const session = JSON.stringify(feedback.session_export)
@@ -23,6 +27,8 @@ export async function sendFeedback(feedback) {
     const child = Bun.spawn({
       cmd: [
         "mail",
+        "-r",
+        sender,
         "-s",
         `hpcGPT Feedback [${feedback.uid}] [${feedback.category}]`,
         "-a",


### PR DESCRIPTION
## Summary
- add a separately configured feedback sender to the Delta modulefile template
- pass `HPCGPT_FEEDBACK_FROM` to `mail -r`
- document the sender environment variable
- keep production sender and recipient values in the private deployed modulefile

## Validation
- exercised `/feedback` through OpenCode 1.18.23 with a fake `mail` executable
- verified the configured sender, recipient, subject, body, and 50-message attachment
- no real email was sent
- `git diff --check` passes