### PR TITLE
Limit documentation output to ten contexts

### DIFF
--- a/NCSA/mcp_servers/illinois_chat_server/server.py
+++ b/NCSA/mcp_servers/illinois_chat_server/server.py
@@ -113,7 +113,7 @@ class ChatMCP(FastMCP):
                 return "No relevant documentation context was found."
             if isinstance(contexts, str):
                 return contexts
-            return json.dumps(contexts, ensure_ascii=True)
+            return json.dumps(contexts[:10], ensure_ascii=True)
         if "message" in data:
             return data["message"]
         if (


### PR DESCRIPTION
## Summary
Limit Illinois Chat documentation tool output to the first 10 retrieved contexts while preserving the existing JSON-string response format.

## Evidence
A live retrieval returned 100 contexts: about 229 KB after decoding and 474 KB over MCP, which triggered OpenCode tool-output truncation. This client-side cap reduces the output sent to OpenCode without changing Illinois Chat retrieval behavior or the MCP response type.

## Validation
- `python -m py_compile server.py src/config.py`
- mocked 12-context response returned valid JSON text containing exactly the first 10 contexts